### PR TITLE
add copy instance and replace instance command

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "./node_modules/mocha/bin/mocha --recursive tst"
   },
   "dependencies": {
-    "aws-sdk": "2.9.0",
+    "aws-sdk": "2.41.0",
     "bluebird": "3.4.7",
     "js-yaml": "3.7.0",
     "validator": "4.4.0",

--- a/src/api/aws_util.js
+++ b/src/api/aws_util.js
@@ -160,13 +160,19 @@ function _get_instance_by_name(region, name) {
 			]
 		})
 		.then(function (data) {
-			if (data.Reservations &&
-				data.Reservations.length &&
-				data.Reservations[0].Instances &&
-				data.Reservations[0].Instances.length) {
-					return data.Reservations[0].Instances[0];
+			const instances = data.Reservations.reduce(function (result, current) {
+				return result.concat(current.Instances);
+			}, []);
+
+			if (!instances.length) {
+				throw new Error(`Instance not found: ${name}`);
 			}
-			return null;
+
+			if (instances.length > 1) {
+				throw new Error(`Instance name is not unique: ${name}`);
+			}
+
+			return instances[0];
 		});
 }
 

--- a/src/api/aws_util.js
+++ b/src/api/aws_util.js
@@ -169,7 +169,10 @@ function _get_instance_by_name(region, name) {
 			}
 
 			if (instances.length > 1) {
-				throw new Error(`Instance name is not unique: ${name}`);
+				const instanceIds = instances.map(function (instance) {
+					return instance.InstanceId;
+				});
+				throw new Error(`Instance name not unique: ${name} is used by ${instanceIds.join(',')}`);
 			}
 
 			return instances[0];

--- a/src/api/aws_util.js
+++ b/src/api/aws_util.js
@@ -144,6 +144,26 @@ function _get_account_id() {
 	});
 }
 
+function _get_instance_by_name(region, name) {
+	return AWSProvider
+		.get_ec2(region)
+		.describeInstancesAsync({
+			Filters: [
+				{
+					Name: 'tag:Name',
+					Values: [name]
+				},
+				{
+					Name: 'instance-state-name',
+					Values: ['running']
+				}
+			]
+		})
+		.then(function (data) {
+			return data.Reservations[0].Instances[0];
+		});
+}
+
 exports.get_asg = _get_asg;
 exports.get_sg_id = _get_sg_id;
 exports.get_vpc_id = _get_vpc_id;
@@ -152,5 +172,5 @@ exports.get_ami_id = _get_ami_id;
 exports.get_sg_ids = _get_sg_ids;
 exports.get_subnet_ids = _get_subnet_ids;
 exports.get_account_id = _get_account_id;
-
-exports.get_bdms =_get_bdms;
+exports.get_bdms = _get_bdms;
+exports.get_instance_by_name = _get_instance_by_name;

--- a/src/api/aws_util.js
+++ b/src/api/aws_util.js
@@ -160,7 +160,13 @@ function _get_instance_by_name(region, name) {
 			]
 		})
 		.then(function (data) {
-			return data.Reservations[0].Instances[0];
+			if (data.Reservations &&
+				data.Reservations.length &&
+				data.Reservations[0].Instances &&
+				data.Reservations[0].Instances.length) {
+					return data.Reservations[0].Instances[0];
+			}
+			return null;
 		});
 }
 

--- a/src/api/instance/copy.js
+++ b/src/api/instance/copy.js
@@ -68,9 +68,8 @@ function copy_instance_attrs(region, instanceId) {
 			get_instance_userdata(region, instanceId),
 			get_instance_volumes(region, instanceId)
 		])
-		.spread(function () {
-			let args = [].slice.call(arguments);
-			return Object.assign.apply(Object, [{}].concat(args));
+		.spread(function (instance_info, instance_userdata, instance_volumes) {
+			return Object.assign({}, instance_info, instance_userdata, instance_volumes);
 		});
 }
 

--- a/src/api/instance/copy.js
+++ b/src/api/instance/copy.js
@@ -85,7 +85,9 @@ function get_instance_info(region, instanceId) {
 
 			return {
 				ImageId: instance.ImageId,
-				IamInstanceProfile: pick(instance.IamInstanceProfile, ['Arn']),
+				IamInstanceProfile: {
+					Arn: instance.IamInstanceProfile.Arn
+				},
 				MaxCount: 1,
 				MinCount: 1,
 				Placement: instance.Placement,
@@ -156,12 +158,4 @@ function get_instance_volumes(region, instanceId) {
 
 			return {BlockDeviceMappings: volumes};
 		});
-}
-
-function pick(obj, keys) {
-	const result = {};
-	keys.forEach(function (k) {
-		result[k] = obj[k];
-	});
-	return result;
 }

--- a/src/api/instance/copy.js
+++ b/src/api/instance/copy.js
@@ -1,0 +1,142 @@
+'use strict';
+
+const Promise = require('bluebird');
+const AWSProvider = require('../aws_provider');
+const AWSUtil = require('../aws_util');
+const logger = require('../../logger');
+
+module.exports = function (regions, instance_name, rename) {
+	const region = regions[0];
+
+	return AWSUtil
+		.get_instance_by_name(region, instance_name)
+		.then(function (instance) {
+			logger.info(`Copy attributes from ${instance_name}`);
+			return copy_instance_attrs(region, instance.InstanceId);
+		})
+		.then(function (instance_attrs) {
+			return rename_instance(instance_attrs, rename);
+		})
+		.then(function (params) {
+			logger.info(`Start instance ${rename}`);
+			return AWSProvider.get_ec2(region).runInstancesAsync(params);
+		})
+		.then(function (data) {
+			return data.Instances[0].InstanceId;
+		});
+};
+
+function rename_instance(instance_attrs, rename) {
+	let Tags = instance_attrs.TagSpecifications[0].Tags;
+
+	Tags = [{Key: 'Name', Value: rename}].concat(
+		Tags.filter(function (t) {
+			return t.Key !== 'Name';
+		})
+	);
+
+	instance_attrs.TagSpecifications[0].Tags = Tags;
+	return instance_attrs;
+}
+
+function copy_instance_attrs(region, instanceId) {
+	return Promise
+		.all([
+			get_instance_info(region, instanceId),
+			get_instance_userdata(region, instanceId),
+			get_instance_volumes(region, instanceId)
+		])
+		.spread(function () {
+			let args = [].slice.call(arguments);
+			return Object.assign.apply(Object, [{}].concat(args));
+		});
+}
+
+function get_instance_info(region, instanceId) {
+	return AWSProvider
+		.get_ec2(region)
+		.describeInstancesAsync({
+			InstanceIds: [instanceId]
+		})
+		.then(function (data) {
+			return data.Reservations[0].Instances[0];
+		})
+		.then(function (instance) {
+			return {
+				ImageId: instance.ImageId,
+				IamInstanceProfile: pick(instance.IamInstanceProfile, ['Arn']),
+				MaxCount: 1,
+				MinCount: 1,
+				Placement: instance.Placement,
+				KeyName: instance.KeyName,
+				TagSpecifications: [
+					{
+						ResourceType: 'instance',
+						Tags: instance.Tags
+					}
+				],
+				InstanceType: instance.InstanceType,
+				EbsOptimized: instance.EbsOptimized,
+				NetworkInterfaces: instance.NetworkInterfaces.map(function (eni) {
+					return {
+						AssociatePublicIpAddress: true,
+						DeviceIndex: 0,
+						Groups: eni.Groups.map(function (group) {
+							return group.GroupId;
+						}),
+						SubnetId: eni.SubnetId
+					};
+				}),
+				Monitoring: {
+					Enabled: true
+				}
+			};
+		});
+}
+
+function get_instance_userdata(region, instanceId) {
+	return AWSProvider
+		.get_ec2(region)
+		.describeInstanceAttributeAsync({
+			Attribute: 'userData',
+			InstanceId: instanceId
+		})
+		.then(function (data) {
+			return {UserData: data.UserData.Value};
+		});
+}
+
+function get_instance_volumes(region, instanceId) {
+	return AWSProvider
+		.get_ec2(region)
+		.describeVolumesAsync({
+			Filters: [
+				{
+					Name: "attachment.instance-id",
+					Values: [instanceId]
+				}
+			]
+		})
+		.then(function (data) {
+			const volumes = data.Volumes.map(function (vol) {
+				return {
+					DeviceName: vol.Attachments[0].Device,
+					Ebs: {
+						VolumeType: vol.VolumeType,
+						VolumeSize: vol.Size,
+						DeleteOnTermination: true
+					}
+				};
+			});
+
+			return {BlockDeviceMappings: volumes};
+		});
+}
+
+function pick(obj, keys) {
+	const result = {};
+	keys.forEach(function (k) {
+		result[k] = obj[k];
+	});
+	return result;
+}

--- a/src/api/instance/copy.js
+++ b/src/api/instance/copy.js
@@ -149,7 +149,7 @@ function get_instance_volumes(region, instanceId) {
 						Ebs: {
 							VolumeType: vol.VolumeType,
 							VolumeSize: vol.Size,
-							DeleteOnTermination: true
+							DeleteOnTermination: vol.Attachments[0].DeleteOnTermination
 						}
 					};
 				});

--- a/src/api/instance/index.js
+++ b/src/api/instance/index.js
@@ -1,3 +1,5 @@
 'use strict';
 
 exports.create = require('./create');
+exports.copy = require('./copy');
+exports.replace = require('./replace');

--- a/src/api/instance/replace.js
+++ b/src/api/instance/replace.js
@@ -77,7 +77,7 @@ function wait_until_healthy(region, lbName, instanceId) {
 			});
 	}
 
-	return helper(region, lbName, instanceId, 10);
+	return helper(region, lbName, instanceId, 20);
 }
 
 function get_instance_lb(region, instanceId) {

--- a/src/api/instance/replace.js
+++ b/src/api/instance/replace.js
@@ -23,8 +23,12 @@ function replace(region, target_name, source_name) {
 		source = s;
 	}).then(function () {
 		return get_instance_lb(region, target.InstanceId);
-	}).then(function (name) {
-		lbName = name;
+	}).then(function (lb) {
+		if (lb == null) {
+			throw new Error(`Instance ${target_name} is not linked to a load balancer`);
+		}
+
+		lbName = lb.LoadBalancerName;
 	}).then(function () {
 		logger.info(`Attach ${source_name} to ${lbName}`);
 		return attach_to_lb(region, lbName, source.InstanceId);
@@ -68,9 +72,6 @@ function get_instance_lb(region, instanceId) {
 					return instance.InstanceId === instanceId;
 				});
 			});
-		})
-		.then(function (lb) {
-			return lb.LoadBalancerName;
 		});
 }
 

--- a/src/api/instance/replace.js
+++ b/src/api/instance/replace.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const Promise = require('bluebird');
+
+const AWSProvider = require('../aws_provider');
+const AWSUtil = require('../aws_util');
+const logger = require('../../logger');
+
+module.exports = function (regions, target_name, source_name) {
+	const region = regions[0];
+
+	let target, source, lbName;
+
+	return Promise.all([
+		AWSUtil.get_instance_by_name(region, target_name),
+		AWSUtil.get_instance_by_name(region, source_name)
+	]).spread(function (t, s) {
+		target = t;
+		source = s;
+	}).then(function () {
+		return get_instance_lb(region, target.InstanceId);
+	}).then(function (name) {
+		lbName = name;
+	}).then(function () {
+		logger.info(`Attach ${source_name} to ${lbName}`);
+		return attach_to_lb(region, lbName, source.InstanceId);
+	}).then(function () {
+		logger.info(`Health check for ${source_name}`);
+		return wait_until_healthy(region, lbName, source.InstanceId);
+	}).then(function () {
+		logger.info(`Detach ${target_name} from ${lbName}`);
+		return detach_from_lb(region, lbName, target.InstanceId);
+	}).then(function () {
+		logger.info(`Terminate ${target_name}`);
+		return terminate_instance(region, target.InstanceId);
+	});
+};
+
+function wait_until_healthy(region, lbName, instanceId) {
+	function helper(region, lbName, instanceId, retry) {
+		return AWSProvider
+			.get_elb(region)
+			.describeInstanceHealthAsync({
+				LoadBalancerName: lbName,
+				Instances: [
+					{InstanceId: instanceId}
+				]
+			})
+			.then(function (data) {
+				const healthy = data.InstanceStates.every(function (state) {
+					return state.State === 'InService';
+				});
+
+				if (!healthy) {
+					if (retry) {
+						logger.info('Retry in 30 seconds');
+						return new Promise(function (resolve) {
+							setTimeout(function () {
+								resolve(helper(region, lbName, instanceId, retry - 1));
+							}, 30000);
+						});
+					} else {
+						throw new Error('Health check failed');
+					}
+				}
+			});
+	}
+
+	return helper(region, lbName, instanceId, 10);
+}
+
+function get_instance_lb(region, instanceId) {
+	return get_lbs(region)
+		.then(function (lbs) {
+			return lbs.find(function (lb) {
+				return lb.Instances.some(function (instance) {
+					return instance.InstanceId === instanceId;
+				});
+			});
+		})
+		.then(function (lb) {
+			return lb.LoadBalancerName;
+		});
+}
+
+function get_lbs(region) {
+	return AWSProvider
+		.get_elb(region)
+		.describeLoadBalancersAsync()
+		.then(function (data) {
+			return data.LoadBalancerDescriptions;
+		})
+		.catch(function () {
+			return [];
+		});
+}
+
+
+function attach_to_lb(region, lbName, instanceId) {
+	return AWSProvider
+		.get_elb(region)
+		.registerInstancesWithLoadBalancerAsync({
+			Instances: [{InstanceId: instanceId}],
+			LoadBalancerName: lbName
+		});
+}
+
+function detach_from_lb(region, lbName, instanceId) {
+	return AWSProvider
+		.get_elb(region)
+		.deregisterInstancesFromLoadBalancerAsync({
+			Instances: [{InstanceId: instanceId}],
+			LoadBalancerName: lbName
+		});
+}
+
+function terminate_instance(region, instanceId) {
+	return AWSProvider
+		.get_ec2(region)
+		.terminateInstancesAsync({
+			InstanceIds: [instanceId]
+		});
+}

--- a/src/cli/arg_handler.js
+++ b/src/cli/arg_handler.js
@@ -240,6 +240,19 @@ function _handle_replace(cmd) {
 				process.exit(1);
 			});
 			break;
+		case 'instance':
+			nemesys.instance.replace(
+				cmd.opts['regions'],
+				cmd.opts['target'],
+				cmd.opts['source']
+			).then(function () {
+				Logger.info('replace complete');
+				process.exit(0);
+			}).catch(function (err) {
+				Logger.error(err.stack);
+				process.exit(1);
+			});
+			break;
 		default:
 			Logger.info(`Unrecognized command: ${cmd.command} ${cmd.target}`);
 			process.exit(1);
@@ -281,6 +294,27 @@ function _handle_update(cmd) {
 	}
 }
 
+function _handle_copy(cmd) {
+	switch(cmd.target) {
+		case 'instance':
+			nemesys.instance.copy(
+				cmd.opts['regions'],
+				cmd.opts['instance'],
+				cmd.opts['rename']
+			).then(function (id) {
+				Logger.info(`copied instance to ${id}`);
+				process.exit(0);
+			}).catch(function(err){
+				Logger.error(err.stack);
+				process.exit(1);
+			});
+			break;
+		default:
+			Logger.info(`Unrecognized command: ${cmd.command} ${cmd.target}`);
+			process.exit(1);
+	}
+}
+
 function _handle(cmd) {
 	switch(cmd.command) {
 		case 'update':
@@ -297,6 +331,10 @@ function _handle(cmd) {
 
 		case 'delete':
 			_handle_delete(cmd);
+			break;
+
+		case 'copy':
+			_handle_copy(cmd);
 			break;
 
 		default:

--- a/src/cli/parse_args.js
+++ b/src/cli/parse_args.js
@@ -398,7 +398,7 @@ function parse_args (args) {
 							describe: 'Target instance name'
 						})
 						.option('i', ingress_rules_opt)
-						.example('nemesys replace instance -s 123 -t 456 -r us-east-1',	'Replaces target instance with src instance')
+						.example('nemesys replace instance -s source-instance-name -t target-instance-name -r us-east-1', 'Replaces target instance with src instance')
 						.help('h')
 						.alias('h', 'help');
 				})
@@ -470,7 +470,7 @@ function parse_args (args) {
 							alias: 'rename',
 							describe: 'New instance name'
 						})
-						.example('nemesys copy instance -i 123 -n new-name')
+						.example('nemesys copy instance -i instance-name -n new-instance-name -r us-east-1')
 						.help('h')
 						.alias('h', 'help');
 				});

--- a/src/cli/parse_args.js
+++ b/src/cli/parse_args.js
@@ -387,6 +387,22 @@ function parse_args (args) {
 						.alias('h', 'help');
 				})
 
+				.command('instance', 'Replace instance with another', function (yargs) {
+					_common_args(yargs)
+						.option('s', {
+							alias:    'source',
+							describe: 'Source instance name'
+						})
+						.option('t', {
+							alias:    'target',
+							describe: 'Target instance name'
+						})
+						.option('i', ingress_rules_opt)
+						.example('nemesys replace instance -s 123 -t 456 -r us-east-1',	'Replaces target instance with src instance')
+						.help('h')
+						.alias('h', 'help');
+				})
+
 				.demand(2)
 				.help('h')
 				.alias('h', 'help');
@@ -442,6 +458,23 @@ function parse_args (args) {
 				.alias('h', 'help');
 		})
 
+		.command('copy', 'Copy an EC2 resource', function (yargs) {
+			yargs
+				.command('instance', 'Copy an instance', function (yargs) {
+					_common_args(yargs)
+						.option('i', {
+							alias: 'instance',
+							describe: 'Instance name'
+						})
+						.option('n', {
+							alias: 'rename',
+							describe: 'New instance name'
+						})
+						.example('nemesys copy instance -i 123 -n new-name')
+						.help('h')
+						.alias('h', 'help');
+				});
+		})
 		.demand(2)
 		.help('h')
 		.alias('h', 'help')
@@ -504,20 +537,22 @@ function del_undef(obj) {
 function _validate(command) {
 	// TODO - I really think this validation belongs to the actual commands themselves and not the arg parser
 	const demands = {
-		'update asg':      ['regions', 'group', 'launch-config'],
-		'update sg':       ['regions', 'security-group'],
-		'create asg':      ['regions', 'vpc', 'group', 'launch-config'],
-		'create sg':       ['regions', 'vpc', 'security-group'],
-		'create alb':      ['regions', 'vpc', 'security-group', 'name'],
-		'create lc':       ['regions', 'launch-config', 'ami', 'instance-type', 'ssh-key-pair'],
-		'create instance': ['regions', 'ami', 'instance-type', 'ssh-key-pair', 'availability-zone', 'vpc'],
-		'create ami':      ['regions', 'ami', 'base-ami', 'instance-type', 'ssh-key-pair', 'availability-zone', 'vpc'],
-		'replace asg':     ['regions', 'vpc', 'group', 'launch-config', 'old-group'],
-		'replace sg':      ['regions', 'security-group', 'ingress-rules'],
-		'delete asg':      ['regions', 'group'],
-		'delete lc':       ['regions', 'launch-config'],
-		'delete sg':       ['regions', 'security-group'],
-		'delete ami':      ['regions', 'ami'],
+		'update asg':       ['regions', 'group', 'launch-config'],
+		'update sg':        ['regions', 'security-group'],
+		'create asg':       ['regions', 'vpc', 'group', 'launch-config'],
+		'create sg':        ['regions', 'vpc', 'security-group'],
+		'create alb':       ['regions', 'vpc', 'security-group', 'name'],
+		'create lc':        ['regions', 'launch-config', 'ami', 'instance-type', 'ssh-key-pair'],
+		'create instance':  ['regions', 'ami', 'instance-type', 'ssh-key-pair', 'availability-zone', 'vpc'],
+		'create ami':       ['regions', 'ami', 'base-ami', 'instance-type', 'ssh-key-pair', 'availability-zone', 'vpc'],
+		'replace asg':      ['regions', 'vpc', 'group', 'launch-config', 'old-group'],
+		'replace sg':       ['regions', 'security-group', 'ingress-rules'],
+		'replace instance': ['regions', 'source', 'target'],
+		'delete asg':       ['regions', 'group'],
+		'delete lc':        ['regions', 'launch-config'],
+		'delete sg':        ['regions', 'security-group'],
+		'delete ami':       ['regions', 'ami'],
+		'copy instance':    ['regions', 'instance', 'rename']
 	};
 
 	let missing = [],

--- a/tst/api/instance/copy.test.js
+++ b/tst/api/instance/copy.test.js
@@ -8,125 +8,75 @@ const AWSProvider = require('../../../src/api/aws_provider');
 const AWSUtil = require('../../../src/api/aws_util');
 const instance = require('../../../src/api/instance');
 
-const mock_ec2 = {
-	runInstancesAsync: function (params) {
-		expect(params).to.eql({
-			MaxCount: 1,
-			MinCount: 1,
-			Monitoring: {
-				Enabled: true
-			},
-			ImageId: 'image_id',
-			IamInstanceProfile: {
-				Arn: 'arn'
-			},
-			BlockDeviceMappings: [],
-			Placement: {},
-			KeyName: 'key_name',
-			TagSpecifications: [
-				{
-					ResourceType: 'instance',
-					Tags: [
-						{
-							Key: 'Name',
-							Value: 'new-instance'
-						}
-					]
-				}
-			],
-			InstanceType: 'instance_type',
-			EbsOptimized: true,
-			NetworkInterfaces: [],
-			UserData: 'user_data'
-		});
-
-		return Promise.resolve({
-			Instances: [
-				{InstanceId: '456'}
-			]
-		});
-	},
-	describeInstancesAsync: function (params) {
-		expect(params).to.eql({
-			InstanceIds: ['123']
-		});
-
-		return Promise.resolve({
-			Reservations: [
-				{
-					Instances: [
-						{
-							ImageId: 'image_id',
-							IamInstanceProfile: {
-								Arn: 'arn'
-							},
-							BlockDeviceMappings: [],
-							Placement: {},
-							KeyName: 'key_name',
-							Tags: [],
-							InstanceType: 'instance_type',
-							EbsOptimized: true,
-							NetworkInterfaces: []
-						}
-					]
-				}
-			]
-		});
-	},
-	describeInstanceAttributeAsync: function (params) {
-		expect(params).to.eql({
-			Attribute: 'userData',
-			InstanceId: '123'
-		});
-
-		return Promise.resolve({
-			UserData: {
-				Value: 'user_data'
-			}
-		});
-	},
-	describeVolumesAsync: function (params) {
-		expect(params).to.eql({
-			Filters: [
-				{
-					Name: "attachment.instance-id",
-					Values: ['123']
-				}
-			]
-		});
-		return Promise.resolve({Volumes: []});
-	},
-	waitForAsync: function (state, params) {
-		expect(state).to.eql('instanceRunning');
-		expect(params).to.eql({
-			InstanceIds: ['456']
-		});
-		return Promise.resolve({
-			Reservations: [
-				{
-					Instances: [
-						{
-							InstanceId: '456',
-							State: {
-								Name: 'running'
-							}
-						}
-					]
-				}
-			]
-		});
-	}
-};
-
 describe('instance copy', function () {
-	let sandbox;
+	let sandbox, mock_ec2;
 
 	beforeEach(function () {
 		sandbox = sinon.sandbox.create();
-		sandbox.stub(AWSProvider, 'get_ec2', () => mock_ec2);
 		sandbox.stub(AWSUtil, 'get_instance_by_name', () => Promise.resolve({
 			InstanceId: '123'
 		}));
+
+		mock_ec2 = {
+			runInstancesAsync: sandbox.stub().returns(
+				Promise.resolve({
+					Instances: [
+						{InstanceId: '456'}
+					]
+				})
+			),
+			describeInstancesAsync: sandbox.stub().returns(
+				Promise.resolve({
+					Reservations: [
+						{
+							Instances: [
+								{
+									ImageId: 'image_id',
+									IamInstanceProfile: {
+										Arn: 'arn'
+									},
+									BlockDeviceMappings: [],
+									Placement: {},
+									KeyName: 'key_name',
+									Tags: [],
+									InstanceType: 'instance_type',
+									EbsOptimized: true,
+									NetworkInterfaces: []
+								}
+							]
+						}
+					]
+				})
+			),
+			describeInstanceAttributeAsync: sandbox.stub().returns(
+				Promise.resolve({
+					UserData: {
+						Value: 'user_data'
+					}
+				})
+			),
+			describeVolumesAsync: sandbox.stub().returns(
+				Promise.resolve({Volumes: []})
+			),
+			waitForAsync: sandbox.stub().returns(
+				Promise.resolve({
+					Reservations: [
+						{
+							Instances: [
+								{
+									InstanceId: '456',
+									State: {
+										Name: 'running'
+									}
+								}
+							]
+						}
+					]
+				})
+			)
+		};
+
+		sandbox.stub(AWSProvider, 'get_ec2', () => mock_ec2);
 	});
 
 	afterEach(function () {
@@ -137,6 +87,59 @@ describe('instance copy', function () {
 		return instance
 			.copy(['us-east-1'], 'old-instance', 'new-instance')
 			.then(function (result) {
+				expect(mock_ec2.runInstancesAsync.calledWith({
+					MaxCount: 1,
+					MinCount: 1,
+					Monitoring: {
+						Enabled: true
+					},
+					ImageId: 'image_id',
+					IamInstanceProfile: {
+						Arn: 'arn'
+					},
+					BlockDeviceMappings: [],
+					Placement: {},
+					KeyName: 'key_name',
+					TagSpecifications: [
+						{
+							ResourceType: 'instance',
+							Tags: [
+								{
+									Key: 'Name',
+									Value: 'new-instance'
+								}
+							]
+						}
+					],
+					InstanceType: 'instance_type',
+					EbsOptimized: true,
+					NetworkInterfaces: [],
+					UserData: 'user_data'
+				})).to.be.true;
+
+				expect(mock_ec2.describeInstancesAsync.calledWith({
+					InstanceIds: ['123']
+				})).to.be.true;
+
+				expect(mock_ec2.describeInstanceAttributeAsync.calledWith({
+					Attribute: 'userData',
+					InstanceId: '123'
+				})).to.be.true;
+
+				expect(mock_ec2.describeVolumesAsync.calledWith({
+					Filters: [
+						{
+							Name: "attachment.instance-id",
+							Values: ['123']
+						}
+					]
+				})).to.be.true;
+
+				expect(mock_ec2.waitForAsync.calledWith(
+					'instanceRunning',
+					{InstanceIds: ['456']}
+				)).to.be.true;
+
 				expect(result).eql(['456']);
 			});
 	});

--- a/tst/api/instance/copy.test.js
+++ b/tst/api/instance/copy.test.js
@@ -95,6 +95,26 @@ const mock_ec2 = {
 			]
 		});
 		return Promise.resolve({Volumes: []});
+	},
+	waitForAsync: function (state, params) {
+		expect(state).to.eql('instanceRunning');
+		expect(params).to.eql({
+			InstanceIds: ['456']
+		});
+		return Promise.resolve({
+			Reservations: [
+				{
+					Instances: [
+						{
+							InstanceId: '456',
+							State: {
+								Name: 'running'
+							}
+						}
+					]
+				}
+			]
+		});
 	}
 };
 

--- a/tst/api/instance/copy.test.js
+++ b/tst/api/instance/copy.test.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const Promise = require('bluebird');
+const expect = require('chai').expect;
+const sinon = require('sinon');
+
+const AWSProvider = require('../../../src/api/aws_provider');
+const AWSUtil = require('../../../src/api/aws_util');
+const instance = require('../../../src/api/instance');
+
+const mock_ec2 = {
+	runInstancesAsync: function (params) {
+		expect(params).to.eql({
+			MaxCount: 1,
+			MinCount: 1,
+			Monitoring: {
+				Enabled: true
+			},
+			ImageId: 'image_id',
+			IamInstanceProfile: {
+				Arn: 'arn'
+			},
+			BlockDeviceMappings: [],
+			Placement: {},
+			KeyName: 'key_name',
+			TagSpecifications: [
+				{
+					ResourceType: 'instance',
+					Tags: [
+						{
+							Key: 'Name',
+							Value: 'new-instance'
+						}
+					]
+				}
+			],
+			InstanceType: 'instance_type',
+			EbsOptimized: true,
+			NetworkInterfaces: [],
+			UserData: 'user_data'
+		});
+
+		return Promise.resolve({
+			Instances: [
+				{InstanceId: '456'}
+			]
+		});
+	},
+	describeInstancesAsync: function (params) {
+		expect(params).to.eql({
+			InstanceIds: ['123']
+		});
+
+		return Promise.resolve({
+			Reservations: [
+				{
+					Instances: [
+						{
+							ImageId: 'image_id',
+							IamInstanceProfile: {
+								Arn: 'arn'
+							},
+							BlockDeviceMappings: [],
+							Placement: {},
+							KeyName: 'key_name',
+							Tags: [],
+							InstanceType: 'instance_type',
+							EbsOptimized: true,
+							NetworkInterfaces: []
+						}
+					]
+				}
+			]
+		});
+	},
+	describeInstanceAttributeAsync: function (params) {
+		expect(params).to.eql({
+			Attribute: 'userData',
+			InstanceId: '123'
+		});
+
+		return Promise.resolve({
+			UserData: {
+				Value: 'user_data'
+			}
+		});
+	},
+	describeVolumesAsync: function (params) {
+		expect(params).to.eql({
+			Filters: [
+				{
+					Name: "attachment.instance-id",
+					Values: ['123']
+				}
+			]
+		});
+		return Promise.resolve({Volumes: []});
+	}
+};
+
+describe('instance copy', function () {
+	let sandbox;
+
+	beforeEach(function () {
+		sandbox = sinon.sandbox.create();
+		sandbox.stub(AWSProvider, 'get_ec2', () => mock_ec2);
+		sandbox.stub(AWSUtil, 'get_instance_by_name', () => Promise.resolve({
+			InstanceId: '123'
+		}));
+	});
+
+	afterEach(function () {
+		sandbox.restore();
+	});
+
+	it('should copy an existing instance', function () {
+		return instance
+			.copy('us-east-1', 'old-instance', 'new-instance')
+			.then(function (newInstanceId) {
+				expect(newInstanceId).eql('456');
+			});
+	});
+});

--- a/tst/api/instance/copy.test.js
+++ b/tst/api/instance/copy.test.js
@@ -115,9 +115,9 @@ describe('instance copy', function () {
 
 	it('should copy an existing instance', function () {
 		return instance
-			.copy('us-east-1', 'old-instance', 'new-instance')
-			.then(function (newInstanceId) {
-				expect(newInstanceId).eql('456');
+			.copy(['us-east-1'], 'old-instance', 'new-instance')
+			.then(function (result) {
+				expect(result).eql(['456']);
 			});
 	});
 });

--- a/tst/api/instance/replace.test.js
+++ b/tst/api/instance/replace.test.js
@@ -43,6 +43,25 @@ const mock_elb = {
 				{State: 'InService'}
 			]
 		});
+	},
+	waitForAsync: function (state, params) {
+		expect(state).to.eql('instanceInService');
+		expect(params).to.eql({
+			LoadBalancerName: 'lb',
+			Instances: [
+				{
+					InstanceId: '123'
+				}
+			]
+		});
+
+		return Promise.resolve({
+			InstanceStates: [
+				{
+					State: 'InService'
+				}
+			]
+		});
 	}
 };
 

--- a/tst/api/instance/replace.test.js
+++ b/tst/api/instance/replace.test.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const Promise = require('bluebird');
+const expect = require('chai').expect;
+const sinon = require('sinon');
+
+const AWSProvider = require('../../../src/api/aws_provider');
+const AWSUtil = require('../../../src/api/aws_util');
+const instance = require('../../../src/api/instance');
+
+const mock_elb = {
+	registerInstancesWithLoadBalancerAsync: function (params) {
+		expect(params).to.eql({
+			Instances: [{InstanceId: '123'}],
+			LoadBalancerName: 'lb'
+		});
+
+		return Promise.resolve({});
+	},
+	deregisterInstancesFromLoadBalancerAsync: function (params) {
+		expect(params).to.eql({
+			Instances: [{InstanceId: '456'}],
+			LoadBalancerName: 'lb'
+		});
+
+		return Promise.resolve({});
+	},
+	describeLoadBalancersAsync: function () {
+		return Promise.resolve({
+			LoadBalancerDescriptions: [
+				{
+					LoadBalancerName: 'lb',
+					Instances: [
+						{InstanceId: '456'}
+					]
+				}
+			]
+		});
+	},
+	describeInstanceHealthAsync: function () {
+		return Promise.resolve({
+			InstanceStates: [
+				{State: 'InService'}
+			]
+		});
+	}
+};
+
+const mock_ec2 = {
+	terminateInstancesAsync: function () {
+		return Promise.resolve();
+	}
+};
+
+describe('instance replace', function () {
+	let sandbox;
+
+	beforeEach(function () {
+		sandbox = sinon.sandbox.create();
+		sandbox.stub(AWSProvider, 'get_elb', () => mock_elb);
+		sandbox.stub(AWSProvider, 'get_ec2', () => mock_ec2);
+		sandbox.stub(AWSUtil, 'get_instance_by_name', (region, name) => {
+			if (name === 'old-instance') {
+				return Promise.resolve({
+					InstanceId: '456'
+				});
+			} else if (name === 'new-instance') {
+				return Promise.resolve({
+					InstanceId: '123'
+				});
+			}
+			return Promise.resolve();
+		});
+	});
+
+	afterEach(function () {
+		sandbox.restore();
+	});
+
+	it('should replace an instance', function () {
+		return instance.replace('us-east-1', 'old-instance', 'new-instance');
+	});
+});

--- a/tst/api/instance/replace.test.js
+++ b/tst/api/instance/replace.test.js
@@ -78,6 +78,6 @@ describe('instance replace', function () {
 	});
 
 	it('should replace an instance', function () {
-		return instance.replace('us-east-1', 'old-instance', 'new-instance');
+		return instance.replace(['us-east-1'], 'old-instance', 'new-instance');
 	});
 });


### PR DESCRIPTION
* Add `copy instance` command
`copy instance` takes an instance name and starts a new instance with exactly the same settings as the given one.
* Add `replace instance` command
`replace instance` takes an old instance name and new instance name, attach the new instance to the same load balancer as the old one, and then detach the old instance, and terminate it.

Limitations:
* Right now replace only works for load balancers
* Instance name has to be unique across the region