### PR TITLE
Add ability to override attributes when copying instance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemesys",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "author": "CQuotient Engineering",
   "repository": "cquotient/nemesys",
   "scripts": {

--- a/src/api/aws_util.js
+++ b/src/api/aws_util.js
@@ -28,6 +28,9 @@ function _get_sg_id(region, group_name) {
 }
 
 function _get_vpc_id(region, vpc_name) {
+	if(!vpc_name) {
+		return Promise.resolve();
+	}
 	return AWSProvider.get_ec2(region).describeVpcsAsync({
 		Filters: [
 			{
@@ -82,13 +85,19 @@ function _get_ami_id(region, ami_name) {
 			}
 		]
 	};
-	return AWSProvider.get_ec2(region).describeImagesAsync(params)
+return AWSProvider.get_ec2(region).describeImagesAsync(params)
 	.then(function(data){
+		if(!data.hasOwnProperty('Images') || !data.Images.length) {
+			return null;
+		}
 		return data.Images[0].ImageId;
 	});
 }
 
 function _get_sg_ids(region, sg) {
+	if(!sg) {
+		return Promise.resolve();
+	}
 	let proms = sg.map(function(name){
 		return _get_sg_id(region, name);
 	});
@@ -119,6 +128,9 @@ function _get_subnet_ids(region, vpc_name, azs) {
 }
 
 function _get_bdms(disks) {
+	if(!disks) {
+		return null;
+	}
 	return disks.map(function(d){
 		let d_split = d.split(':');
 		let bdm = {
@@ -180,6 +192,9 @@ function _get_instance_by_name(region, name) {
 }
 
 function _get_network_interface(region, vpc, az, eni_name, sg) {
+	if(!sg || !vpc || !az) {
+		return Promise.resolve();
+	}
 	let subnet_id_promise = _get_subnet_ids(region, vpc, [az]).then((subnet_ids) => subnet_ids[0]);
 	let sg_ids_promise = _get_sg_ids(region, sg);
 	return BB.all([

--- a/src/api/aws_util.js
+++ b/src/api/aws_util.js
@@ -29,7 +29,7 @@ function _get_sg_id(region, group_name) {
 
 function _get_vpc_id(region, vpc_name) {
 	if(!vpc_name) {
-		return Promise.reject('Must provide a VPC name.');
+		return Promise.reject(new Error('Must provide a VPC name.'));
 	}
 	return AWSProvider.get_ec2(region).describeVpcsAsync({
 		Filters: [
@@ -96,7 +96,7 @@ return AWSProvider.get_ec2(region).describeImagesAsync(params)
 
 function _get_sg_ids(region, sg) {
 	if(!sg) {
-		return Promise.reject('Must provide a list of security groups');
+		return Promise.reject(new Error('Must provide a list of security groups'));
 	}
 	let proms = sg.map(function(name){
 		return _get_sg_id(region, name);
@@ -193,7 +193,7 @@ function _get_instance_by_name(region, name) {
 
 function _get_network_interface(region, vpc, az, eni_name, sg) {
 	if(!sg || !vpc) {
-		return Promise.reject('Must provide security groups and VPC');
+		return Promise.reject(new Error('Must provide security groups and VPC'));
 	}
 	let subnet_id_promise = _get_subnet_ids(region, vpc, [az]).then((subnet_ids) => subnet_ids[0]);
 	let sg_ids_promise = _get_sg_ids(region, sg);

--- a/src/api/aws_util.js
+++ b/src/api/aws_util.js
@@ -192,7 +192,7 @@ function _get_instance_by_name(region, name) {
 }
 
 function _get_network_interface(region, vpc, az, eni_name, sg) {
-	if(!sg || !vpc || !az) {
+	if(!sg || !vpc) {
 		return Promise.resolve();
 	}
 	let subnet_id_promise = _get_subnet_ids(region, vpc, [az]).then((subnet_ids) => subnet_ids[0]);

--- a/src/api/aws_util.js
+++ b/src/api/aws_util.js
@@ -29,7 +29,7 @@ function _get_sg_id(region, group_name) {
 
 function _get_vpc_id(region, vpc_name) {
 	if(!vpc_name) {
-		return Promise.resolve();
+		return Promise.reject('Must provide a VPC name.');
 	}
 	return AWSProvider.get_ec2(region).describeVpcsAsync({
 		Filters: [
@@ -96,7 +96,7 @@ return AWSProvider.get_ec2(region).describeImagesAsync(params)
 
 function _get_sg_ids(region, sg) {
 	if(!sg) {
-		return Promise.resolve();
+		return Promise.reject('Must provide a list of security groups');
 	}
 	let proms = sg.map(function(name){
 		return _get_sg_id(region, name);
@@ -193,7 +193,7 @@ function _get_instance_by_name(region, name) {
 
 function _get_network_interface(region, vpc, az, eni_name, sg) {
 	if(!sg || !vpc) {
-		return Promise.resolve();
+		return Promise.reject('Must provide security groups and VPC');
 	}
 	let subnet_id_promise = _get_subnet_ids(region, vpc, [az]).then((subnet_ids) => subnet_ids[0]);
 	let sg_ids_promise = _get_sg_ids(region, sg);

--- a/src/api/aws_util.js
+++ b/src/api/aws_util.js
@@ -221,6 +221,16 @@ function _get_network_interface(region, vpc, az, eni_name, sg) {
 	});
 }
 
+function _get_ud_files(ud_files, rud_files, region_index) {
+	// TODO: currently insance copy/create do not support raw userdata strings.
+	let rud_file = rud_files && rud_files[region_index] ? rud_files[region_index] : null;
+	if(!ud_files) ud_files = [];
+	if(rud_file) {
+		ud_files = [rud_file].concat(ud_files);
+	}
+	return ud_files;
+}
+
 function _get_eni_id(region, vpc, az, eni_name) {
 	let EC2 = AWSProvider.get_ec2(region);
 	return _get_vpc_id(region, vpc)
@@ -258,3 +268,4 @@ exports.get_bdms = _get_bdms;
 exports.get_instance_by_name = _get_instance_by_name;
 exports.get_network_interface = _get_network_interface;
 exports.get_eni_id = _get_eni_id;
+exports.get_ud_files = _get_ud_files;

--- a/src/api/aws_util.js
+++ b/src/api/aws_util.js
@@ -156,6 +156,23 @@ function _get_account_id() {
 	});
 }
 
+function _get_instance_tag_specifications(tags) {
+	if(!tags || !tags.length) {
+		return null;
+	}
+	let split_tags;
+	if (tags && tags.length > 0) {
+		split_tags = tags.map(function(tag_str) {
+			let kv = tag_str.split('=');
+			return {Key: kv[0], Value: kv[1]};
+		});
+	}
+	return [{
+		ResourceType: 'instance',
+		Tags: split_tags
+	}];
+}
+
 function _get_instance_by_name(region, name) {
 	return AWSProvider
 		.get_ec2(region)
@@ -265,6 +282,7 @@ exports.get_sg_ids = _get_sg_ids;
 exports.get_subnet_ids = _get_subnet_ids;
 exports.get_account_id = _get_account_id;
 exports.get_bdms = _get_bdms;
+exports.get_instance_tag_specifications = _get_instance_tag_specifications;
 exports.get_instance_by_name = _get_instance_by_name;
 exports.get_network_interface = _get_network_interface;
 exports.get_eni_id = _get_eni_id;

--- a/src/api/aws_util.js
+++ b/src/api/aws_util.js
@@ -222,7 +222,7 @@ function _get_network_interface(region, vpc, az, eni_name, sg) {
 }
 
 function _get_ud_files(ud_files, rud_files, region_index) {
-	// TODO: currently insance copy/create do not support raw userdata strings.
+	// TODO: currently instance copy/create do not support raw userdata strings.
 	let rud_file = rud_files && rud_files[region_index] ? rud_files[region_index] : null;
 	if(!ud_files) ud_files = [];
 	if(rud_file) {

--- a/src/api/instance/copy.js
+++ b/src/api/instance/copy.js
@@ -4,6 +4,7 @@ const Promise = require('bluebird');
 const AWSProvider = require('../aws_provider');
 const AWSUtil = require('../aws_util');
 const logger = require('../../logger');
+const Override = require('../override');
 
 module.exports = function (regions, instance_name, rename, vpc, ami, i_type, key_name, sg, iam, ud_files, rud_file, raw_ud_string, disks, az, tags, eni_name, env_vars, ebs_opt) {
 	if(!ud_files) ud_files = [];
@@ -38,7 +39,7 @@ function copy(region, instance_name, rename, override_opts) {
 			return copy_instance_attrs(region, instance.InstanceId);
 		})
 		.then(function (instance_attrs) {
-			return merge_config(region, instance_attrs, override_opts).then(merged => {
+			return Override.merge_config(region, instance_attrs, override_opts).then(merged => {
 				return rename_instance(merged, rename);
 			});
 		})
@@ -50,50 +51,6 @@ function copy(region, instance_name, rename, override_opts) {
 			logger.info('Wait for instance intialization');
 			return wait_until_runnning(region, data.Instances[0].InstanceId);
 		});
-}
-
-function _build_override_params(region, oo) {
-	return Promise.all([
-			AWSUtil.get_ami_id(region, oo.ami),
-			AWSUtil.get_userdata_string(oo.ud_files, oo.env_vars, oo.raw_ud_string),
-			AWSUtil.get_network_interface(region, oo.vpc, oo.az, oo.eni_name, oo.sg),
-			AWSUtil.get_bdms(oo.disks)
-		])
-		.spread(function(ami_id, userdata_string, network_interface, bdms){
-			let config = {
-				BlockDeviceMappings: bdms,
-				ImageId: ami_id,
-				InstanceType: oo.i_type,
-				KeyName: oo.key_name,
-				NetworkInterfaces: network_interface,
-			};
-			if (typeof(oo.ebs_opt) === 'boolean') {
-				config.EbsOptimized = !!oo.ebs_opt;
-			}
-			if (oo.iam) {
-				config.IamInstanceProfile = {
-					Name: oo.iam
-				};
-			}
-			if ((oo.ud_files && oo.ud_files.length) || oo.raw_ud_string) {
-				config.UserData = new Buffer(userdata_string).toString('base64');
-			}
-			return config;
-		});
-}
-
-function merge_config(region, orig_config, override_opts) {
-	return _build_override_params(region, override_opts).then(function(override_config) {
-		for (let key of Object.keys(override_config)) {
-			let val = override_config[key];
-			// Don't assign null, empty or undefined configurations
-			if (val == null || (Array.isArray(val) && !val.length)) {
-				delete override_config[key];
-			}
-		}
-		let new_config = Object.assign(orig_config, override_config);
-		return new_config;
-	});
 }
 
 function wait_until_runnning(region, instanceId) {

--- a/src/api/instance/copy.js
+++ b/src/api/instance/copy.js
@@ -6,27 +6,32 @@ const AWSUtil = require('../aws_util');
 const logger = require('../../logger');
 const Override = require('../override');
 
-module.exports = function (regions, instance_name, rename, vpc, ami, i_type, key_name, sg, iam, ud_files, rud_file, raw_ud_string, disks, az, tags, eni_name, env_vars, ebs_opt) {
-	if(!ud_files) ud_files = [];
-	if(rud_file) {
-		ud_files = [rud_file].concat(ud_files);
-	}
-	let override_opts = {
-		vpc: vpc,
-		ami: ami,
-		i_type: i_type,
-		key_name: key_name,
-		sg: sg,
-		iam: iam,
-		ud_files: ud_files,
-		disks: disks,
-		az: az,
-		tags: tags,
-		eni_name: eni_name,
-		env_vars: env_vars,
-		ebs_opt: ebs_opt
-	};
-	return Promise.all(regions.map(function (region) {
+module.exports = function (regions, instance_name, rename, vpc, ami, i_type, key_name, sg, iam, ud_files, rud_files, raw_ud_string, disks, az, tags, eni_name, env_vars, ebs_opt) {
+	return Promise.all(regions.map(function (region, idx) {
+		let zone;
+		if (az) {
+			zone = az.length == regions.length ? az[idx] : az[0];
+		}
+		let rud_file = rud_files && rud_files[idx] ? rud_files[idx] : null;
+		if(!ud_files) ud_files = [];
+		if(rud_file) {
+			ud_files = [rud_file].concat(ud_files);
+		}
+		let override_opts = {
+			vpc: vpc,
+			ami: ami,
+			i_type: i_type,
+			key_name: key_name,
+			sg: sg,
+			iam: iam,
+			ud_files: ud_files,
+			disks: disks,
+			az: zone,
+			tags: tags,
+			eni_name: eni_name,
+			env_vars: env_vars,
+			ebs_opt: ebs_opt
+		};
 		return copy(region, instance_name, rename, override_opts);
 	}));
 };

--- a/src/api/instance/copy.js
+++ b/src/api/instance/copy.js
@@ -12,11 +12,7 @@ module.exports = function (regions, instance_name, rename, vpc, ami, i_type, key
 		if (az) {
 			zone = az.length == regions.length ? az[idx] : az[0];
 		}
-		let rud_file = rud_files && rud_files[idx] ? rud_files[idx] : null;
-		if(!ud_files) ud_files = [];
-		if(rud_file) {
-			ud_files = [rud_file].concat(ud_files);
-		}
+		let userdata_files = AWSUtil.get_ud_files(ud_files, raw_ud_string, idx);
 		let override_opts = {
 			vpc: vpc,
 			ami: ami,
@@ -24,7 +20,7 @@ module.exports = function (regions, instance_name, rename, vpc, ami, i_type, key
 			key_name: key_name,
 			sg: sg,
 			iam: iam,
-			ud_files: ud_files,
+			ud_files: userdata_files,
 			disks: disks,
 			az: zone,
 			tags: tags,

--- a/src/api/instance/create.js
+++ b/src/api/instance/create.js
@@ -23,14 +23,8 @@ function _resolve_instance(ec2, region, instance_id) {
 	});
 }
 
-function _do_create(region, vpc, ami, i_type, key_name, sg, iam, ud_files, rud_file, raw_ud_string, disks, az, tags, eni_name, env_vars, ebs_opt) {
-	if(!ud_files) ud_files = [];
-	if(rud_file) {
-		ud_files = [rud_file].concat(ud_files);
-	}
-
+function _do_create(region, vpc, ami, i_type, key_name, sg, iam, ud_files, raw_ud_string, disks, az, tags, eni_name, env_vars, ebs_opt) {
 	let EC2 = AWSProvider.get_ec2(region);
-
 	return BB.all([
 		AWSUtil.get_ami_id(region, ami),
 		AWSUtil.get_userdata_string(ud_files, env_vars, raw_ud_string),
@@ -89,8 +83,8 @@ function create(regions, vpc, ami, i_type, key_name, sg, iam, ud_files, rud_file
 	}
 	let region_promises = regions.map(function(region, idx){
 		let zone = az.length == regions.length ? az[idx] : az[0];
-		let rud_file = rud_files && rud_files[idx] ? rud_files[idx] : null;
-		return _do_create(region, vpc, ami, i_type, key_name, sg, iam, ud_files, rud_file, raw_ud_string, disks, zone, tags, eni_name, env_vars, ebs_opt);
+		let userdata_files = AWSUtil.get_ud_files(ud_files, rud_files, idx);
+		return _do_create(region, vpc, ami, i_type, key_name, sg, iam, userdata_files, raw_ud_string, disks, zone, tags, eni_name, env_vars, ebs_opt);
 	});
 	return BB.all(region_promises);
 }

--- a/src/api/instance/create.js
+++ b/src/api/instance/create.js
@@ -6,55 +6,6 @@ const Logger = require('../../logger');
 const AWSUtil = require('../aws_util');
 const AWSProvider = require('../aws_provider');
 
-function _get_eni_id(ec2, region, vpc, az, eni_name) {
-	return AWSUtil.get_vpc_id(region, vpc)
-	.then(function(vpc_id){
-		return ec2.describeNetworkInterfacesAsync({
-			Filters: [
-				{
-					Name: 'vpc-id',
-					Values: [vpc_id]
-				},
-				{
-					Name: 'availability-zone',
-					Values: [region + az]
-				},
-				{
-					Name: 'tag:Name',
-					Values: [eni_name]
-				}
-			]
-		});
-	}).then(function(data){
-		return data.NetworkInterfaces[0].NetworkInterfaceId;
-	});
-}
-
-function _get_network_interface(ec2, region, vpc, az, eni_name, sg_ids_promise, subnet_id_promise) {
-	return BB.all([
-		sg_ids_promise,
-		subnet_id_promise
-	])
-	.then(function(results){
-		if(eni_name) {
-			return _get_eni_id(ec2, region, vpc, az, eni_name)
-			.then(function(eni_id){
-				return {
-					DeviceIndex: 0,
-					NetworkInterfaceId: eni_id
-				};
-			});
-		} else {
-			return Promise.resolve({
-				AssociatePublicIpAddress: true,
-				DeviceIndex: 0,
-				Groups: results[0],
-				SubnetId: results[1]
-			});
-		}
-	});
-}
-
 function _resolve_instance(ec2, region, instance_id) {
 	return new Promise(function(resolve, reject){
 		function _check(){
@@ -80,16 +31,13 @@ function _do_create(region, vpc, ami, i_type, key_name, sg, iam, ud_files, rud_f
 
 	let EC2 = AWSProvider.get_ec2(region);
 
-	let sg_ids_promise = AWSUtil.get_sg_ids(region, sg);
-	let subnet_id_promise = AWSUtil.get_subnet_ids(region, vpc, [az]).then((subnet_ids) => subnet_ids[0]);
-
 	return BB.all([
 		AWSUtil.get_ami_id(region, ami),
 		AWSUtil.get_userdata_string(ud_files, env_vars, raw_ud_string),
-		_get_network_interface(EC2, region, vpc, az, eni_name, sg_ids_promise, subnet_id_promise)
+		AWSUtil.get_network_interface(region, vpc, az, eni_name, sg),
+		AWSUtil.get_bdms(disks)
 	])
-	.spread(function(ami_id, userdata_string, network_interface){
-		let bdms = AWSUtil.get_bdms(disks);
+	.spread(function(ami_id, userdata_string, network_interface, bdms){
 		return {
 			BlockDeviceMappings: bdms,
 			EbsOptimized: !!ebs_opt,

--- a/src/api/override.js
+++ b/src/api/override.js
@@ -4,11 +4,12 @@ const Promise = require('bluebird');
 const AWSUtil = require('./aws_util');
 
 function _build_override_params(region, oo) {
+	// If these fail, we fall back to the default parameters
 	return Promise.all([
-			AWSUtil.get_ami_id(region, oo.ami),
-			AWSUtil.get_userdata_string(oo.ud_files, oo.env_vars, oo.raw_ud_string),
-			AWSUtil.get_network_interface(region, oo.vpc, oo.az, oo.eni_name, oo.sg),
-			AWSUtil.get_bdms(oo.disks)
+			AWSUtil.get_ami_id(region, oo.ami).catch(() => null),
+			AWSUtil.get_userdata_string(oo.ud_files, oo.env_vars, oo.raw_ud_string).catch(() => null),
+			AWSUtil.get_network_interface(region, oo.vpc, oo.az, oo.eni_name, oo.sg).catch(() => null),
+			AWSUtil.get_bdms(oo.disks) // Not a promise
 		])
 		.spread(function(ami_id, userdata_string, network_interface, bdms){
 			let config = {

--- a/src/api/override.js
+++ b/src/api/override.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const Promise = require('bluebird');
+const AWSUtil = require('./aws_util');
+
+function _build_override_params(region, oo) {
+	return Promise.all([
+			AWSUtil.get_ami_id(region, oo.ami),
+			AWSUtil.get_userdata_string(oo.ud_files, oo.env_vars, oo.raw_ud_string),
+			AWSUtil.get_network_interface(region, oo.vpc, oo.az, oo.eni_name, oo.sg),
+			AWSUtil.get_bdms(oo.disks)
+		])
+		.spread(function(ami_id, userdata_string, network_interface, bdms){
+			let config = {
+				BlockDeviceMappings: bdms,
+				ImageId: ami_id,
+				InstanceType: oo.i_type,
+				KeyName: oo.key_name,
+				NetworkInterfaces: network_interface,
+			};
+			if (typeof(oo.ebs_opt) === 'boolean') {
+				config.EbsOptimized = !!oo.ebs_opt;
+			}
+			if (oo.iam) {
+				config.IamInstanceProfile = {
+					Name: oo.iam
+				};
+			}
+			if ((oo.ud_files && oo.ud_files.length) || oo.raw_ud_string) {
+				config.UserData = new Buffer(userdata_string).toString('base64');
+			}
+			return config;
+		});
+}
+
+function merge_config(region, orig_config, override_opts) {
+	return _build_override_params(region, override_opts).then(function(override_config) {
+		for (let key of Object.keys(override_config)) {
+			let val = override_config[key];
+			// Don't assign null, empty or undefined configurations
+			if (val == null || (Array.isArray(val) && !val.length)) {
+				delete override_config[key];
+			}
+		}
+		let new_config = Object.assign(orig_config, override_config);
+		return new_config;
+	});
+}
+
+module.exports = {
+	merge_config
+};

--- a/src/api/override.js
+++ b/src/api/override.js
@@ -9,15 +9,17 @@ function _build_override_params(region, oo) {
 			AWSUtil.get_ami_id(region, oo.ami).catch(() => null),
 			AWSUtil.get_userdata_string(oo.ud_files, oo.env_vars, oo.raw_ud_string).catch(() => null),
 			AWSUtil.get_network_interface(region, oo.vpc, oo.az, oo.eni_name, oo.sg).catch(() => null),
-			AWSUtil.get_bdms(oo.disks) // Not a promise
+			AWSUtil.get_bdms(oo.disks), // Not a promise,
+			AWSUtil.get_instance_tag_specifications(oo.tags) // Not a promise
 		])
-		.spread(function(ami_id, userdata_string, network_interface, bdms){
+		.spread(function(ami_id, userdata_string, network_interface, bdms, tags){
 			let config = {
 				BlockDeviceMappings: bdms,
 				ImageId: ami_id,
 				InstanceType: oo.i_type,
 				KeyName: oo.key_name,
 				NetworkInterfaces: network_interface,
+				TagSpecifications: tags
 			};
 			if (typeof(oo.ebs_opt) === 'boolean') {
 				config.EbsOptimized = !!oo.ebs_opt;

--- a/src/cli/arg_handler.js
+++ b/src/cli/arg_handler.js
@@ -300,7 +300,23 @@ function _handle_copy(cmd) {
 			nemesys.instance.copy(
 				cmd.opts['regions'],
 				cmd.opts['instance'],
-				cmd.opts['rename']
+				cmd.opts['rename'],
+				// Copy supports all parameters supported by 'create'
+				cmd.opts['vpc'],
+				cmd.opts['ami'],
+				cmd.opts['instance-type'],
+				cmd.opts['ssh-key-pair'],
+				cmd.opts['security-groups'],
+				cmd.opts['iam-role'],
+				cmd.opts['user-data-files'],
+				cmd.opts['region-user-data'] || [], //yargs default breaks merging command line args w/ config file, so do it here
+				null, //raw userdata string not supported from command line atm
+				cmd.opts['disks'],
+				cmd.opts['availability-zone'],
+				cmd.opts['tags'],
+				cmd.opts['network-interface'],
+				cmd.opts['env'],
+				cmd.opts['optimize-ebs']
 			).then(function (id) {
 				Logger.info(`copied instance to ${id}`);
 				process.exit(0);

--- a/src/cli/parse_args.js
+++ b/src/cli/parse_args.js
@@ -470,7 +470,57 @@ function parse_args (args) {
 							alias: 'rename',
 							describe: 'New instance name'
 						})
-						.example('nemesys copy instance -i instance-name -n new-instance-name -r us-east-1')
+						.option('a', {
+							alias:       'ami',
+							description: 'AMI name'
+						})
+						.option('b', {
+							alias: 'base-ami',
+							description: 'Name of the base AMI to override with'
+						})
+						.option('t', {
+							alias:    'instance-type',
+							describe: 'EC2 API name of the instance type to use on the copied instance (ie, m3.large)'
+						})
+						.option('k', {
+							alias:    'ssh-key-pair',
+							describe: 'Name of the ssh key pair to use for instances using this Launch Configuration'
+						})
+						.option('I', {
+							alias:    'iam-role',
+							describe: 'IAM role to use on the copied instance'
+						})
+						.option('s', {
+							alias:    'security-groups',
+							describe: 'Name of the Security Group(s) to apply to instances using this Launch Configuration',
+							array:    true
+						})
+						.option('u', {
+							alias:    'user-data-files',
+							describe: 'Shell script files to combine to form the user data on the copied instance',
+							array:    true
+						})
+						.option('region-user-data', {
+							describe: 'Region-specific user data files, which will appear BEFORE all other user data in the resulting script. This must be in the same order as the regions passed in via --regions',
+							array:    true
+						})
+						.option('d', {
+							alias:    'disks',
+							describe: 'Disks to attach to the copied instance using this Launch Configuration',
+							array:    true
+						})
+						.option('z', {
+							alias:    'availability-zone',
+							describe: 'Availability zone to launch the copied instance in. If more than one, will be used in order of regions arg',
+							array:    true
+						})
+						.option('v', vpc_opt)
+						.option('preserve-instance', {
+							describe: 'Keep instance running after creating AMI',
+							type: 'boolean',
+							default: false
+						})
+						.example('nemesys copy instance -i instance-name -n new-instance-name -r us-east-1 -t m4.2xlarge')
 						.help('h')
 						.alias('h', 'help');
 				});

--- a/src/cli/parse_args.js
+++ b/src/cli/parse_args.js
@@ -520,6 +520,11 @@ function parse_args (args) {
 							type: 'boolean',
 							default: false
 						})
+						.option('T', {
+							alias:    'tags',
+							describe: 'Tags to apply, in the form of Name=value',
+							array:    true
+						})
 						.example('nemesys copy instance -i instance-name -n new-instance-name -r us-east-1 -t m4.2xlarge')
 						.help('h')
 						.alias('h', 'help');

--- a/tst/api/instance/copy.test.js
+++ b/tst/api/instance/copy.test.js
@@ -9,13 +9,16 @@ const AWSUtil = require('../../../src/api/aws_util');
 const instance = require('../../../src/api/instance');
 
 describe('instance copy', function () {
-	let sandbox, mock_ec2;
+	let sandbox, mock_ec2, expected_run_args;
 
 	beforeEach(function () {
 		sandbox = sinon.sandbox.create();
 		sandbox.stub(AWSUtil, 'get_instance_by_name', () => Promise.resolve({
 			InstanceId: '123'
 		}));
+		sandbox.stub(AWSUtil, 'get_ami_id', (region, ami_name) => Promise.resolve(
+			ami_name
+		));
 
 		mock_ec2 = {
 			runInstancesAsync: sandbox.stub().returns(
@@ -75,7 +78,35 @@ describe('instance copy', function () {
 				})
 			)
 		};
-
+		expected_run_args = {
+			MaxCount: 1,
+			MinCount: 1,
+			Monitoring: {
+				Enabled: true
+			},
+			ImageId: 'image_id',
+			IamInstanceProfile: {
+				Arn: 'arn'
+			},
+			BlockDeviceMappings: [],
+			Placement: {},
+			KeyName: 'key_name',
+			TagSpecifications: [
+				{
+					ResourceType: 'instance',
+					Tags: [
+						{
+							Key: 'Name',
+							Value: 'new-instance'
+						}
+					]
+				}
+			],
+			InstanceType: 'instance_type',
+			EbsOptimized: true,
+			NetworkInterfaces: [],
+			UserData: 'user_data'
+		};
 		sandbox.stub(AWSProvider, 'get_ec2', () => mock_ec2);
 	});
 
@@ -87,35 +118,149 @@ describe('instance copy', function () {
 		return instance
 			.copy(['us-east-1'], 'old-instance', 'new-instance')
 			.then(function (result) {
-				expect(mock_ec2.runInstancesAsync.calledWith({
-					MaxCount: 1,
-					MinCount: 1,
-					Monitoring: {
-						Enabled: true
-					},
-					ImageId: 'image_id',
-					IamInstanceProfile: {
-						Arn: 'arn'
-					},
-					BlockDeviceMappings: [],
-					Placement: {},
-					KeyName: 'key_name',
-					TagSpecifications: [
-						{
-							ResourceType: 'instance',
-							Tags: [
-								{
-									Key: 'Name',
-									Value: 'new-instance'
-								}
-							]
-						}
-					],
-					InstanceType: 'instance_type',
-					EbsOptimized: true,
-					NetworkInterfaces: [],
-					UserData: 'user_data'
+				expect(mock_ec2.runInstancesAsync.calledWith(expected_run_args)).to.be.true;
+
+				expect(mock_ec2.describeInstancesAsync.calledWith({
+					InstanceIds: ['123']
 				})).to.be.true;
+
+				expect(mock_ec2.describeInstanceAttributeAsync.calledWith({
+					Attribute: 'userData',
+					InstanceId: '123'
+				})).to.be.true;
+
+				expect(mock_ec2.describeVolumesAsync.calledWith({
+					Filters: [
+						{
+							Name: "attachment.instance-id",
+							Values: ['123']
+						}
+					]
+				})).to.be.true;
+
+				expect(mock_ec2.waitForAsync.calledWith(
+					'instanceRunning',
+					{InstanceIds: ['456']}
+				)).to.be.true;
+
+				expect(result).eql(['456']);
+			});
+	});
+
+	it('should copy an existing instance and override the instance type', function () {
+		return instance
+			.copy(['us-east-1'], 'old-instance', 'new-instance', null, null, 'other_type')
+			.then(function (result) {
+				let expected = expected_run_args;
+				expected.InstanceType = 'other_type';
+				expect(mock_ec2.runInstancesAsync.calledWith(expected)).to.be.true;
+				expect(mock_ec2.describeInstancesAsync.calledWith({
+					InstanceIds: ['123']
+				})).to.be.true;
+
+				expect(mock_ec2.describeInstanceAttributeAsync.calledWith({
+					Attribute: 'userData',
+					InstanceId: '123'
+				})).to.be.true;
+
+				expect(mock_ec2.describeVolumesAsync.calledWith({
+					Filters: [
+						{
+							Name: "attachment.instance-id",
+							Values: ['123']
+						}
+					]
+				})).to.be.true;
+
+				expect(mock_ec2.waitForAsync.calledWith(
+					'instanceRunning',
+					{InstanceIds: ['456']}
+				)).to.be.true;
+
+				expect(result).eql(['456']);
+			});
+	});
+
+	it('should copy an existing instance and override the instance type and ami', function () {
+		return instance
+			.copy(['us-east-1'], 'old-instance', 'new-instance', null, 'fancy_ami', 'other_type')
+			.then(function (result) {
+				let expected = expected_run_args;
+				expected.InstanceType = 'other_type';
+				expected.ImageId = 'fancy_ami';
+				expect(mock_ec2.runInstancesAsync.calledWith(expected)).to.be.true;
+
+				expect(mock_ec2.describeInstancesAsync.calledWith({
+					InstanceIds: ['123']
+				})).to.be.true;
+
+				expect(mock_ec2.describeInstanceAttributeAsync.calledWith({
+					Attribute: 'userData',
+					InstanceId: '123'
+				})).to.be.true;
+
+				expect(mock_ec2.describeVolumesAsync.calledWith({
+					Filters: [
+						{
+							Name: "attachment.instance-id",
+							Values: ['123']
+						}
+					]
+				})).to.be.true;
+
+				expect(mock_ec2.waitForAsync.calledWith(
+					'instanceRunning',
+					{InstanceIds: ['456']}
+				)).to.be.true;
+
+				expect(result).eql(['456']);
+			});
+	});
+
+	it('should copy an existing instance and override the instance type and ami', function () {
+		return instance
+			.copy(['us-east-1'], 'old-instance', 'new-instance', null, 'fancy_ami', 'other_type')
+			.then(function (result) {
+				let expected = expected_run_args;
+				expected.InstanceType = 'other_type';
+				expected.ImageId = 'fancy_ami';
+				expect(mock_ec2.runInstancesAsync.calledWith(expected)).to.be.true;
+
+				expect(mock_ec2.describeInstancesAsync.calledWith({
+					InstanceIds: ['123']
+				})).to.be.true;
+
+				expect(mock_ec2.describeInstanceAttributeAsync.calledWith({
+					Attribute: 'userData',
+					InstanceId: '123'
+				})).to.be.true;
+
+				expect(mock_ec2.describeVolumesAsync.calledWith({
+					Filters: [
+						{
+							Name: "attachment.instance-id",
+							Values: ['123']
+						}
+					]
+				})).to.be.true;
+
+				expect(mock_ec2.waitForAsync.calledWith(
+					'instanceRunning',
+					{InstanceIds: ['456']}
+				)).to.be.true;
+
+				expect(result).eql(['456']);
+			});
+	});
+
+	it('should copy an existing instance and disable ebs optimization on the copy', function () {
+		return instance
+			.copy(['us-east-1'], 'old-instance', 'new-instance', null, null, null, null, null, null, null, null, null, null, null, null, null, null, false)
+			.then(function (result) {
+				console.log(require('util').inspect(mock_ec2.runInstancesAsync.getCall(0).args, { depth: null }));
+				let expected = expected_run_args;
+				expected.EbsOptimized = false;
+				expect(mock_ec2.runInstancesAsync.calledWith(expected)).to.be.true;
 
 				expect(mock_ec2.describeInstancesAsync.calledWith({
 					InstanceIds: ['123']

--- a/tst/api/instance/copy.test.js
+++ b/tst/api/instance/copy.test.js
@@ -257,7 +257,6 @@ describe('instance copy', function () {
 		return instance
 			.copy(['us-east-1'], 'old-instance', 'new-instance', null, null, null, null, null, null, null, null, null, null, null, null, null, null, false)
 			.then(function (result) {
-				console.log(require('util').inspect(mock_ec2.runInstancesAsync.getCall(0).args, { depth: null }));
 				let expected = expected_run_args;
 				expected.EbsOptimized = false;
 				expect(mock_ec2.runInstancesAsync.calledWith(expected)).to.be.true;

--- a/tst/api/instance/copy.test.js
+++ b/tst/api/instance/copy.test.js
@@ -331,7 +331,6 @@ describe('instance copy', function () {
 		return instance
 			.copy(['us-east-1'], 'old-instance', 'new-instance', 'fake-vpc-id', null, null, null, ['fake-sg-id'], null, null, null, null, null, null, null, 'fake-network-interface-id', null, null)
 			.then(function (result) {
-				console.log(require('util').inspect(mock_ec2.runInstancesAsync.getCall(0).args, { depth: null }));
 				let expected = expected_run_args;
 				expected.NetworkInterfaces = {
 					DeviceIndex: 0,


### PR DESCRIPTION
Allows the copy command to accept options that can be used to overwrite parameters on the copied instance.

Replacing an instance with changes can be done by 
1. creating a copy of the instance to replace with the specified override options
2. running `replace` on the new instance and the target instance