### PR TITLE
Replace ec2metadata with curl URLs to retrieve instance-id

### DIFF
--- a/src/api/ami/create.js
+++ b/src/api/ami/create.js
@@ -84,7 +84,7 @@ function _do_create(create_region, instance_id, copy_regions, ami_name, disks, p
 }
 
 function _gen_spinup_complete_ud(region) {
-	return `\naws ec2 create-tags --region ${region} --resources \`ec2metadata --instance-id\` --tags Key=Spinup,Value=complete\n`;
+	return `\naws ec2 create-tags --region ${region} --resources \`curl http:\/\/169.254.169.254\/latest\/meta-data\/instance-id\` --tags Key=Spinup,Value=complete\n`;
 }
 
 function create(regions, ami_name, vpc, ami, i_type, key_name, sg, iam, ud_files, rud_files, disks, az, preserve_instance){

--- a/tst/api/ami/create.test.js
+++ b/tst/api/ami/create.test.js
@@ -153,7 +153,7 @@ describe('create ami', function(){
 
 			expected_ud += 'echo "hi there"\n';
 			expected_ud += 'echo "my friend"\n';
-			expected_ud += '\naws ec2 create-tags --region us-east-1 --resources `ec2metadata --instance-id` --tags Key=Spinup,Value=complete\n';
+			expected_ud += '\naws ec2 create-tags --region us-east-1 --resources `curl http://169.254.169.254/latest/meta-data/instance-id` --tags Key=Spinup,Value=complete\n';
 
 			expect(run_instances_spy).to.have.been.calledWith({
 				BlockDeviceMappings: [


### PR DESCRIPTION
ec2metadata scripts are not uniform across a) metadata versions b) langauges
(i.e. python, node, bash) and c) linux distros.  So using the internal tool
within ubuntu/golden_goose AMI will not port to centos/bastion_host AMIs.  By
having nemesys just curl the internal metadata IP (which is what ec2metadata
does anyways) we will be able to use nemesys across different AMIs.

We do lose ec2metadata error handling and wrap around functionaility.  However,
if/when nemesys increases it's use of ec2 meta data we should just vendor
ec2metadata into the nemesys repo (i.e. wrap AWS.MetadataService()).