### PR TITLE
Check targetgroup health status during asg replacement

### DIFF
--- a/src/api/asg/replace.js
+++ b/src/api/asg/replace.js
@@ -105,14 +105,14 @@ function _wait_for_health(region, new_asg_name, new_asg, old_asg) {
 							let result = [];
 							result = result.concat(elb_result
 								.filter(obj => {
-									return obj.State != 'InService' && obj.State != 'Terminated' && obj.State != 'OutOfService';
+									return obj.State == 'InService';
 								}).map(instance => {
 									return instance.InstanceId;
 								})
 							);
 							result = result.concat(tg_result
 								.filter(obj => {
-									return obj.TargetHealth.State != 'healthy' && obj.TargetHealth.State != 'unused';
+									return obj.TargetHealth.State != 'healthy';
 								}).map(instance => {
 									return instance.Target.Id;
 								})
@@ -122,9 +122,9 @@ function _wait_for_health(region, new_asg_name, new_asg, old_asg) {
 									return self.indexOf(item) == pos;
 								});
 						});
-				}).then(function(unhealthy){
-					if(unhealthy.length > 0) {
-						Logger.info(`${region}: found ${unhealthy.length} unhealthy instances (${unhealthy.join(', ')}) - waiting 30s`);
+				}).then(function(healthy){
+					if(healthy.length != new_asg.DesiredCapacity && new_asg.DesiredCapacity != 0) {
+						Logger.info(`${region}: found ${healthy.length} healthy instances in load balancer, but we want (${new_asg.DesiredCapacity}) - waiting 30s`);
 						setTimeout(_check, _delay_ms);
 					} else {
 						Logger.info(`${region}: all hosts healthy in load balancer`);

--- a/src/api/asg/replace.js
+++ b/src/api/asg/replace.js
@@ -83,21 +83,40 @@ function _wait_for_health(region, new_asg_name, new_asg, old_asg) {
 		return new Promise(function(resolve, reject){
 			function _check() {
 				AWSUtil.get_asg(AWSProvider.get_as(region), new_asg_name).then(function(asg){
-					let new_instance_ids = asg.Instances.map((instance) => instance.InstanceId);
-					let inst_elb_check_proms = asg.LoadBalancerNames.map(function(elb){
+					let inst_elb_check_proms = BB.all(asg.LoadBalancerNames.map(function(elb){
 						return AWSProvider.get_elb(region).describeInstanceHealthAsync({
-							LoadBalancerName: elb,
-							Instances: new_instance_ids.map( (inst_id) => ({InstanceId: inst_id}) )
+							LoadBalancerName: elb
 						});
-					});
-					return BB.all(inst_elb_check_proms);
-				}).then(function(elb_results){
-					let unhealthy = elb_results.reduce(function(prev, curr){
-						return prev.concat(curr.InstanceStates
-							.filter((obj) => obj.State && obj.State !== 'InService' && obj.State !== 'Terminated')
-							.map((obj) => obj.InstanceId)
-						);
-					}, []);
+					})).reduce((prev, curr) => {
+							return prev.concat(curr.InstanceStates);
+						}, []);
+					let inst_tg_check_proms = BB.all(asg.TargetGroupARNs.map(function(tg){
+						return AWSProvider.get_elbv2(region).describeTargetHealthAsync({
+							TargetGroupArn: tg
+						});
+					})).reduce((prev, curr) => {
+							return prev.concat(curr.TargetHealthDescriptions);
+						}, []);
+					return BB.all([inst_elb_check_proms, inst_tg_check_proms])
+						.spread((elb_result, tg_result) => {
+							let result = [];
+							result = result.concat(elb_result
+								.filter(obj => {
+									return obj.State != 'InService' && obj.State != 'Terminated';
+								}).map(instance => {
+									return instance.InstanceId;
+								})
+							);
+							result = result.concat(tg_result
+								.filter(obj => {
+									return obj.TargetHealth.State != 'healthy';
+								}).map(instance => {
+									return instance.Target.Id;
+								})
+							);
+							return result;
+						});
+				}).then(function(unhealthy){
 					if(unhealthy.length > 0) {
 						Logger.info(`${region}: found ${unhealthy.length} unhealthy instances (${unhealthy.join(', ')}) - waiting 30s`);
 						setTimeout(_check, _delay_ms);

--- a/tst/api/asg/replace.test.js
+++ b/tst/api/asg/replace.test.js
@@ -490,9 +490,19 @@ describe('replace asg', function(){
 
 			expect(desc_inst_health_spy).to.have.been.calledWith({
 				LoadBalancerName: 'fake-elb1',
+				Instances: [
+					{
+						InstanceId: 'fake-instance-id-1'
+					}
+				]
 			});
 			expect(desc_target_health_spy).to.have.been.calledWith({
-				TargetGroupArn: 'fake-tg-arn'
+				TargetGroupArn: 'fake-tg-arn',
+				Targets: [
+					{
+						Id: 'fake-instance-id-1'
+					}
+				]
 			});
 
 		});

--- a/tst/api/asg/replace.test.js
+++ b/tst/api/asg/replace.test.js
@@ -23,7 +23,8 @@ describe('replace asg', function(){
 			put_alarm_spy,
 			del_sched_act_spy,
 			del_policy_spy,
-			desc_inst_health_spy;
+			desc_inst_health_spy,
+			desc_target_health_spy;
 
 	before(function(){
 		replace = require('../../../src/api/asg/replace');
@@ -36,83 +37,58 @@ describe('replace asg', function(){
 	beforeEach(function(){
 		sandbox = require('sinon').sandbox.create();
 		const mock_as = {
-			describeAutoScalingGroupsAsync: function(params){
+			describeAutoScalingGroupsAsync: function(params) {
+
+				let loadbalancernames, targetgrouparns, instances;
+
 				if(params.AutoScalingGroupNames
 				&& params.AutoScalingGroupNames.length === 1) {
 					let name = params.AutoScalingGroupNames[0];
+
 					if(name === 'fake-new-asg') {
-						let instances = [{
+						loadbalancernames = ['fake-elb1'];
+						targetgrouparns = ['fake-tg-arn'];
+						instances = [{
 							LifecycleState: 'InService',
 							HealthStatus: 'Healthy',
 							InstanceId: 'fake-instance-id-1'
 						}];
-						//TODO: need a way to fake having instances become healthy
-						return Promise.resolve({
-							AutoScalingGroups: [
-								{
-									AutoScalingGroupName: params.AutoScalingGroupNames[0],
-									AutoScalingGroupARN: 'fake-asg-arn',
-									LaunchConfigurationName: 'fake-asg-lc',
-									MinSize: 0,
-									MaxSize: 2,
-									DesiredCapacity: 1,
-									DefaultCooldown: 120,
-									AvailabilityZones: [
-										'fake-az1',
-										'fake-az2'
-									],
-									LoadBalancerNames: [
-										'fake-elb1'
-									],
-									TargetGroupARNs: [
-										'fake-tg-arn'
-									],
-									HealthCheckType: 'elb',
-									HealthCheckGracePeriod: 60,
-									Instances: instances,
-									Tags: [
-										{
-											Key: 'Name',
-											Value: 'fake-name'
-										}
-									]
-								}
-							]
-						});
-					} else {
-						return Promise.resolve({
-							AutoScalingGroups: [
-								{
-									AutoScalingGroupName: params.AutoScalingGroupNames[0],
-									AutoScalingGroupARN: 'fake-asg-arn',
-									LaunchConfigurationName: 'fake-asg-lc',
-									MinSize: 0,
-									MaxSize: 2,
-									DesiredCapacity: 1,
-									DefaultCooldown: 120,
-									AvailabilityZones: [
-										'fake-az1',
-										'fake-az2'
-									],
-									LoadBalancerNames: [
-										'fake-elb1'
-									],
-									TargetGroupARNs: [
-										'fake-tg-arn'
-									],
-									HealthCheckType: 'elb',
-									HealthCheckGracePeriod: 60,
-									Instances: [],
-									Tags: [
-										{
-											Key: 'Name',
-											Value: 'fake-name'
-										}
-									]
-								}
-							]
-						});
+					} else if(name === 'fake-old-asg') {
+						loadbalancernames = ['fake-elb1'];
+						targetgrouparns = ['fake-tg-arn'];
+						instances = [];
 					}
+
+					//TODO: need a way to fake having instances become healthy
+					return Promise.resolve({
+						AutoScalingGroups: [
+							{
+								AutoScalingGroupName: params.AutoScalingGroupNames[0],
+								AutoScalingGroupARN: 'fake-asg-arn',
+								LaunchConfigurationName: 'fake-asg-lc',
+								MinSize: 0,
+								MaxSize: 2,
+								DesiredCapacity: 1,
+								DefaultCooldown: 120,
+								AvailabilityZones: [
+									'fake-az1',
+									'fake-az2'
+								],
+								LoadBalancerNames: loadbalancernames,
+								TargetGroupARNs: targetgrouparns,
+								HealthCheckType: 'elb',
+								HealthCheckGracePeriod: 60,
+								Instances: instances,
+								Tags: [
+									{
+										Key: 'Name',
+										Value: 'fake-name'
+									}
+								]
+							}
+						]
+					});
+
 				} else {
 					return Promise.reject(new Error('bad arg for mocked describeAutoScalingGroupsAsync'));
 				}
@@ -341,6 +317,25 @@ describe('replace asg', function(){
 		};
 		sandbox.stub(AWSProvider, 'get_elb', () => mock_elb);
 		desc_inst_health_spy = sandbox.spy(mock_elb, 'describeInstanceHealthAsync');
+
+		const mock_elbv2 = {
+			describeTargetHealthAsync: function(params){
+				return Promise.resolve({
+					TargetHealthDescriptions: [
+						{
+							Target: {
+								Id: 'fake-instance-id-2'
+							},
+							TargetHealth: {
+								State: 'healthy'
+							}
+						}
+					]
+				});
+			}
+		};
+		sandbox.stub(AWSProvider, 'get_elbv2', () => mock_elbv2);
+		desc_target_health_spy = sandbox.spy(mock_elbv2, 'describeTargetHealthAsync');
 	});
 
 	afterEach(function(){
@@ -495,12 +490,11 @@ describe('replace asg', function(){
 
 			expect(desc_inst_health_spy).to.have.been.calledWith({
 				LoadBalancerName: 'fake-elb1',
-				Instances: [
-					{
-						InstanceId: 'fake-instance-id-1'
-					}
-				]
 			});
+			expect(desc_target_health_spy).to.have.been.calledWith({
+				TargetGroupArn: 'fake-tg-arn'
+			});
+
 		});
 	});
 


### PR DESCRIPTION
Targetgroup needs to be healthy in order for ALBs to route traffic to
them.  This patch requires nemesys to check for target group health
alongside elb and asg health status; all before moving to terminating
the old asg.

This patch should prevent an issue when replacing ASGs with only
targetgroups. The load balancer returns no unhealthy instances,
therefore nemesys proceeds to terminate the old ASG even though the new
ASG can't take new traffic yet.

The way we check is still leaky.  The passing condition is that there
are no unhealthy instances in either the target group or the load
balancer.  But 0 unhealthy instances and no healhty instances are not
synonymous.  In the future, we should probably switch to the
number of healthy instances across elbs and tgs needs to match the
desired capacity.  An additional health check would be to actually hit
the uri endpoint of the load balancer to make sure traffic is routable
before finally terminating the old asg.