### PR TITLE
[jb/elastic-ips.W-4956474] Elastic IPs for instance replacement

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "chai": "^3.5.0",
+    "chai": "^4.1.0",
+    "chai-as-promised": "^7.1.0",
     "eslint": "3.12.2",
     "mocha": "^3.0.1",
     "sinon": "^1.17.5",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "license": "MIT",
   "devDependencies": {
     "chai": "^4.1.0",
-    "chai-as-promised": "^7.1.0",
     "eslint": "3.12.2",
     "mocha": "^3.0.1",
     "sinon": "^1.17.5",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "./node_modules/mocha/bin/mocha --recursive tst"
   },
   "dependencies": {
-    "aws-sdk": "2.230.1",
+    "aws-sdk": "2.231.1",
     "bluebird": "3.4.7",
     "js-yaml": "3.7.0",
     "validator": "4.4.0",

--- a/src/api/aws_provider.js
+++ b/src/api/aws_provider.js
@@ -10,7 +10,7 @@ function _get_ec2(region) {
 	if(!ec2_conns[region]) {
 		ec2_conns[region] = BB.promisifyAll(new AWS.EC2({
 			region: region,
-			apiVersion: '2015-10-01'
+			apiVersion: '2016-11-15'
 		}));
 	}
 	return ec2_conns[region];

--- a/src/api/aws_provider.js
+++ b/src/api/aws_provider.js
@@ -10,7 +10,7 @@ function _get_ec2(region) {
 	if(!ec2_conns[region]) {
 		ec2_conns[region] = BB.promisifyAll(new AWS.EC2({
 			region: region,
-			apiVersion: '2016-11-15'
+			apiVersion: '2015-10-01'
 		}));
 	}
 	return ec2_conns[region];

--- a/src/api/instance/replace.js
+++ b/src/api/instance/replace.js
@@ -58,13 +58,13 @@ function replace(region, target_name, source_name, assign_elastic_ip) {
 				return detach_elastic_ip(region, assoc_id);
 			}
 		}
-		return Promise.resolve(true);
+		return true;
 	}).then(() => {
 		if (assign_elastic_ip && allocation_id) {
 			logger.info(`Attach EIP to ${source_name}`);
 			return attach_elastic_ip(region, source.InstanceId, allocation_id);
 		}
-		return Promise.resolve(true);
+		return true;
 	}).then(() => {
 		logger.info(`Terminate ${target_name}`);
 		return terminate_instance(region, target.InstanceId);

--- a/src/api/instance/replace.js
+++ b/src/api/instance/replace.js
@@ -104,7 +104,7 @@ function attach_elastic_ip(region, source_instance_id, alloc_id) {
 
 	return AWSProvider
 		.get_ec2(region)
-		.associateAddress(params, function(err, data) {
+		.associateAddressAsync(params, function(err, data) {
 			if (err) {
 				console.log("Address Not Associated", err);
 				return false;
@@ -122,7 +122,7 @@ function detach_elastic_ip(region, assoc_id) {
 
 	return AWSProvider
 		.get_ec2(region)
-		.disassociateAddress(params, function(err, data) {
+		.disassociateAddressAsync(params, function(err, data) {
 			if (err) {
 				console.log(err, err.stack);
 				return false;

--- a/src/api/instance/replace.js
+++ b/src/api/instance/replace.js
@@ -44,7 +44,7 @@ function replace(region, target_name, source_name, assign_elastic_ip) {
 		}
 	}).then(eip_hash => {
 		if (assign_elastic_ip) {
-			if (eip_hash.alloc_id && eip_hash.assoc_id) {
+			if (eip_hash && eip_hash.alloc_id && eip_hash.assoc_id) {
 				logger.info(`${region}: Alloc ID: ${eip_hash.alloc_id}`);
 				logger.info(`${region}: Assoc ID: ${eip_hash.assoc_id}`);
 
@@ -64,7 +64,7 @@ function replace(region, target_name, source_name, assign_elastic_ip) {
 	}).then(() => {
 		logger.info(`${region}: Terminate ${target_name}`);
 		return terminate_instance(region, target.InstanceId);
-	}).catch(err => logger.error(err));
+	});
 }
 
 function wait_until_healthy(region, lbName, instanceId) {
@@ -97,7 +97,7 @@ function attach_elastic_ip(region, source_instance_id, alloc_id) {
 		.get_ec2(region)
 		.associateAddressAsync(params)
 		.catch(err => {
-			return Promise.reject(new Error(`${region}: Address was not associated to ${source_instance_id}: ${err}`));
+			Promise.reject(new Error(`${region}: Address was not associated to ${source_instance_id}: ${err}`));
 		});
 }
 
@@ -110,7 +110,7 @@ function detach_elastic_ip(region, assoc_id) {
 		.get_ec2(region)
 		.disassociateAddressAsync(params)
 		.catch(err => {
-			return Promise.reject(new Error(`${region}: Failed to detach elastic IP with association ID ${assoc_id}: ${err}`));
+			Promise.reject(new Error(`${region}: Failed to detach elastic IP with association ID ${assoc_id}: ${err}`));
 		});
 }
 
@@ -151,7 +151,7 @@ function get_elastic_ip(region, target_instance_id) {
 						}
 					}
 				});
-		}).catch((err) => console.log(err));
+		}).catch(() => {});
 }
 
 function get_instance_lb(region, instanceId) {

--- a/src/api/instance/replace.js
+++ b/src/api/instance/replace.js
@@ -95,10 +95,7 @@ function attach_elastic_ip(region, source_instance_id, alloc_id) {
 
 	return AWSProvider
 		.get_ec2(region)
-		.associateAddressAsync(params)
-		.catch(err => {
-			Promise.reject(new Error(`${region}: Address was not associated to ${source_instance_id}: ${err}`));
-		});
+		.associateAddressAsync(params);
 }
 
 function detach_elastic_ip(region, assoc_id) {
@@ -108,10 +105,7 @@ function detach_elastic_ip(region, assoc_id) {
 
 	return AWSProvider
 		.get_ec2(region)
-		.disassociateAddressAsync(params)
-		.catch(err => {
-			Promise.reject(new Error(`${region}: Failed to detach elastic IP with association ID ${assoc_id}: ${err}`));
-		});
+		.disassociateAddressAsync(params);
 }
 
 function get_elastic_ip(region, target_instance_id) {
@@ -133,6 +127,9 @@ function get_elastic_ip(region, target_instance_id) {
 				return data.Reservations[0].Instances[0].PublicIpAddress;
 			}
 		}).then(pub_address => {
+			if (!pub_address) {
+				return;
+			}
 			params = {
 				PublicIps: [pub_address]
 			};
@@ -151,7 +148,7 @@ function get_elastic_ip(region, target_instance_id) {
 						}
 					}
 				});
-		}).catch(() => {});
+		});
 }
 
 function get_instance_lb(region, instanceId) {

--- a/src/api/instance/replace.js
+++ b/src/api/instance/replace.js
@@ -12,8 +12,9 @@ module.exports = function (regions, target_name, source_name) {
 	}));
 };
 
-function replace(region, target_name, source_name) {
-	let target, source, lbName;
+function replace(region, target_name, source_name, assign_elastic_ip) {
+	let target, source, lbName, elastic_ip, allocation_id;
+	assign_elastic_ip = assign_elastic_ip === 'true' : true ? false;
 
 	return Promise.all([
 		AWSUtil.get_instance_by_name(region, target_name),
@@ -39,6 +40,37 @@ function replace(region, target_name, source_name) {
 		logger.info(`Detach ${target_name} from ${lbName}`);
 		return detach_from_lb(region, lbName, target.InstanceId);
 	}).then(function () {
+		if (assign_elastic_ip) {
+			return get_elastic_ip(region, target.InstanceId)
+		}
+	}).then((eip, alloc_id, assoc_id) => {
+		if (assign_elastic_ip) {
+			if (!eip || !alloc_id || !assoc_id) {
+				throw new Error(`Instance ${target_name} had no EIP, but one was expected`);
+			} else {
+				// Record eip for next step
+				elastic_ip = eip;
+				allocation_id = alloc_id;
+
+				// Detach from target
+				return detach_elastic_ip(region, assoc_id)
+			}
+		}
+		return true;
+	}).then(detach_worked => {
+		if (assign_elastic_ip) {
+			if (detach_worked) {
+				// Attach to source
+				return attach_elastic_ip(region, source.InstanceId, allocation_id)
+			} else {
+				throw new Error(`Failed to detach elastic IP from ${target_name}`)
+			}
+		}
+		return true;
+	}).then(attach_worked => function () {
+		if (assign_elastic_ip && !attach_worked) {
+			throw new Error(`Failed to attach elastic IP to ${source_name}`)
+		}
 		logger.info(`Terminate ${target_name}`);
 		return terminate_instance(region, target.InstanceId);
 	});
@@ -61,6 +93,90 @@ function wait_until_healthy(region, lbName, instanceId) {
 			if (state.State !== 'InService') {
 				throw new Error(state.Description);
 			}
+		});
+}
+
+function attach_elastic_ip(region, source_instance_id, alloc_id) {
+	var params = {
+		AllocationId: alloc_id,
+		InstanceId: source_instance_id
+	};
+
+	return AWSProvider
+		.get_ec2(region)
+		.associateAddress(params, function(err, data) {
+			if (err) {
+				console.log("Address Not Associated", err);
+				return false;
+			} else {
+				console.log("Address associated:", data.AssociationId);
+				return true;
+			}
+		});
+}
+
+function detach_elastic_ip(region, assoc_id) {
+	var params = {
+		AssociationId: assoc_id
+	};
+
+	return AWSProvider
+		.get_ec2(region)
+		.disassociateAddress(params, function(err, data) {
+			if (err) {
+				console.log(err, err.stack);
+				return false;
+			} else {
+				return true;
+			}
+		});
+}
+
+function get_elastic_ip(region, instanceId) {
+	var params = {
+		Filters: [
+			{
+				Name: 'instance-id',
+				Values: [instanceId]
+			}
+		]
+	};
+
+	return AWSProvider
+		.get_ec2(region)
+		.describeInstancesAsync(params, function(err, data) {
+			if (err) {
+				console.log("Error", err);
+			} else {
+				if (data.Reservations && data.Reservations.length) {
+					if (data.Reservations[0].Instances && data.Reservations[0].Instances.length) {
+						 return data.Reservations[0].Instances[0].PublicIpAddress;
+					} else {
+						console.log("Had no elastic IP");
+					}
+				} else {
+					console.log("Data had no length");
+				}
+			}
+		}).then(pub_address => {
+			params = {
+				PublicIps: [pub_address]
+			}
+			return AWSProvider
+				.get_ec2(region)
+				.describeAddressesAsync(params, function(err, data) {
+					if (err) {
+						console.log("Error", err);
+					} else if (data.Addresses && data.Addresses.length) {
+						data.Addresses.forEach(address => {
+							if (address.AllocationId) {
+								 return (pub_address, address.AllocationId, address.AssociationId);
+							}
+						});
+					} else {
+						console.log("Data had no length");
+					}
+				});
 		});
 }
 

--- a/src/cli/arg_handler.js
+++ b/src/cli/arg_handler.js
@@ -244,7 +244,8 @@ function _handle_replace(cmd) {
 			nemesys.instance.replace(
 				cmd.opts['regions'],
 				cmd.opts['target'],
-				cmd.opts['source']
+				cmd.opts['source'],
+				cmd.opts['assign-elastic-ip']
 			).then(function () {
 				Logger.info('replace complete');
 				process.exit(0);

--- a/src/cli/parse_args.js
+++ b/src/cli/parse_args.js
@@ -398,6 +398,12 @@ function parse_args (args) {
 							describe: 'Target instance name'
 						})
 						.option('i', ingress_rules_opt)
+						.option('e', {
+							alias: 'assign-elastic-ip',
+							describe: 'Boolean, whether to transfer an elastic IP from the old box to the new; defaults to true',
+							type: 'boolean',
+							default: true
+						})
 						.example('nemesys replace instance -s source-instance-name -t target-instance-name -r us-east-1', 'Replaces target instance with src instance')
 						.help('h')
 						.alias('h', 'help');

--- a/tst/api/instance/replace.test.js
+++ b/tst/api/instance/replace.test.js
@@ -11,6 +11,11 @@ const instance = require('../../../src/api/instance');
 
 describe('instance replace', function () {
 	let sandbox, mock_elb, mock_ec2;
+	let old_instance_id = '456';
+	let new_instance_id = '123';
+	let alloc_id = 'aloc123';
+	let assoc_id = 'assoc123';
+	let pub_ip = '999.999.999.999';
 
 	beforeEach(function () {
 		sandbox = sinon.sandbox.create();
@@ -48,6 +53,29 @@ describe('instance replace', function () {
 		mock_ec2 = {
 			terminateInstancesAsync: sandbox.stub().returns(
 				Promise.resolve()
+			),
+			describeInstancesAsync: sandbox.stub().returns(
+				Promise.resolve({
+					Reservations: [{
+						Instances: [{
+							PublicIpAddress: pub_ip
+						}]
+					}]
+				})
+			),
+			describeAddressesAsync: sandbox.stub().returns(
+				Promise.resolve({
+					Addresses: [{
+						AllocationId: alloc_id,
+						AssociationId: assoc_id
+					}]
+				})
+			),
+			disassociateAddressAsync: sandbox.stub().returns(
+				Promise.resolve()
+			),
+			associateAddressAsync: sandbox.stub().returns(
+				Promise.resolve()
 			)
 		};
 
@@ -56,11 +84,11 @@ describe('instance replace', function () {
 		sandbox.stub(AWSUtil, 'get_instance_by_name', (region, name) => {
 			if (name === 'old-instance') {
 				return Promise.resolve({
-					InstanceId: '456'
+					InstanceId: old_instance_id
 				});
 			} else if (name === 'new-instance') {
 				return Promise.resolve({
-					InstanceId: '123'
+					InstanceId: new_instance_id
 				});
 			}
 			return Promise.resolve();
@@ -71,17 +99,17 @@ describe('instance replace', function () {
 		sandbox.restore();
 	});
 
-	it('should replace an instance', function () {
+	it('should replace an instance when associating an elastic IP successfully', function () {
 		return instance
-			.replace(['us-east-1'], 'old-instance', 'new-instance')
+			.replace(['us-east-1'], 'old-instance', 'new-instance', true)
 			.then(function () {
 				expect(mock_elb.registerInstancesWithLoadBalancerAsync.calledWith({
-					Instances: [{InstanceId: '123'}],
+					Instances: [{InstanceId: new_instance_id}],
 					LoadBalancerName: 'lb'
 				})).to.be.true;
 
 				expect(mock_elb.deregisterInstancesFromLoadBalancerAsync.calledWith({
-					Instances: [{InstanceId: '456'}],
+					Instances: [{InstanceId: old_instance_id}],
 					LoadBalancerName: 'lb'
 				})).to.be.true;
 
@@ -91,11 +119,303 @@ describe('instance replace', function () {
 						LoadBalancerName: 'lb',
 						Instances: [
 							{
-								InstanceId: '123'
+								InstanceId: new_instance_id
 							}
 						]
 					}
 				)).to.be.true;
+
+				expect(mock_ec2.describeInstancesAsync.calledWith({
+					Filters: [
+						{
+							Name: 'instance-id',
+							Values: [old_instance_id]
+						}
+					]
+				})).to.be.true;
+
+				expect(mock_ec2.describeAddressesAsync.calledWith({
+					PublicIps: [pub_ip]
+				})).to.be.true;
+
+				expect(mock_ec2.disassociateAddressAsync.calledWith({
+					AssociationId: assoc_id
+				})).to.be.true;
+
+				expect(mock_ec2.associateAddressAsync.calledWith({
+					AllocationId: alloc_id,
+					InstanceId: new_instance_id
+				})).to.be.true;
+			});
+	});
+
+	it('should replace an instance when not association an elastic IP successfully', function () {
+		return instance
+			.replace(['us-east-1'], 'old-instance', 'new-instance', false)
+			.then(function () {
+				expect(mock_elb.registerInstancesWithLoadBalancerAsync.calledWith({
+					Instances: [{InstanceId: new_instance_id}],
+					LoadBalancerName: 'lb'
+				})).to.be.true;
+
+				expect(mock_elb.deregisterInstancesFromLoadBalancerAsync.calledWith({
+					Instances: [{InstanceId: old_instance_id}],
+					LoadBalancerName: 'lb'
+				})).to.be.true;
+
+				expect(mock_elb.waitForAsync.calledWith(
+					'instanceInService',
+					{
+						LoadBalancerName: 'lb',
+						Instances: [
+							{
+								InstanceId: new_instance_id
+							}
+						]
+					}
+				)).to.be.true;
+
+				expect(mock_ec2.describeInstancesAsync.calledWith({
+					Filters: [
+						{
+							Name: 'instance-id',
+							Values: [old_instance_id]
+						}
+					]
+				})).to.be.false;
+
+				expect(mock_ec2.describeAddressesAsync.calledWith({
+					PublicIps: [pub_ip]
+				})).to.be.false;
+
+				expect(mock_ec2.disassociateAddressAsync.calledWith({
+					AssociationId: assoc_id
+				})).to.be.false;
+
+				expect(mock_ec2.associateAddressAsync.calledWith({
+					AllocationId: alloc_id,
+					InstanceId: new_instance_id
+				})).to.be.false;
+			});
+	});
+
+	it('should replace an instance when associate elastic IP but instance description not found', function () {
+		mock_ec2.describeInstancesAsync = sandbox.stub().returns(
+			Promise.reject(new Error("Something wrong"))
+		);
+		return instance
+			.replace(['us-east-1'], 'old-instance', 'new-instance', true)
+			.then(function () {
+				expect(mock_elb.registerInstancesWithLoadBalancerAsync.calledWith({
+					Instances: [{InstanceId: new_instance_id}],
+					LoadBalancerName: 'lb'
+				})).to.be.true;
+
+				expect(mock_elb.deregisterInstancesFromLoadBalancerAsync.calledWith({
+					Instances: [{InstanceId: old_instance_id}],
+					LoadBalancerName: 'lb'
+				})).to.be.true;
+
+				expect(mock_elb.waitForAsync.calledWith(
+					'instanceInService',
+					{
+						LoadBalancerName: 'lb',
+						Instances: [
+							{
+								InstanceId: new_instance_id
+							}
+						]
+					}
+				)).to.be.true;
+
+				expect(mock_ec2.describeInstancesAsync.calledWith({
+					Filters: [
+						{
+							Name: 'instance-id',
+							Values: [old_instance_id]
+						}
+					]
+				})).to.be.true;
+
+				expect(mock_ec2.describeAddressesAsync.calledWith({
+					PublicIps: [pub_ip]
+				})).to.be.false;
+
+				expect(mock_ec2.disassociateAddressAsync.calledWith({
+					AssociationId: assoc_id
+				})).to.be.false;
+
+				expect(mock_ec2.associateAddressAsync.calledWith({
+					AllocationId: alloc_id,
+					InstanceId: new_instance_id
+				})).to.be.false;
+			});
+	});
+
+	it('should replace an instance when associate elastic IP but EIP not found', function () {
+		mock_ec2.describeAddressesAsync = sandbox.stub().returns(
+			Promise.reject(new Error("Something wrong"))
+		);
+		return instance
+			.replace(['us-east-1'], 'old-instance', 'new-instance', true)
+			.then(function () {
+				expect(mock_elb.registerInstancesWithLoadBalancerAsync.calledWith({
+					Instances: [{InstanceId: new_instance_id}],
+					LoadBalancerName: 'lb'
+				})).to.be.true;
+
+				expect(mock_elb.deregisterInstancesFromLoadBalancerAsync.calledWith({
+					Instances: [{InstanceId: old_instance_id}],
+					LoadBalancerName: 'lb'
+				})).to.be.true;
+
+				expect(mock_elb.waitForAsync.calledWith(
+					'instanceInService',
+					{
+						LoadBalancerName: 'lb',
+						Instances: [
+							{
+								InstanceId: new_instance_id
+							}
+						]
+					}
+				)).to.be.true;
+
+				expect(mock_ec2.describeInstancesAsync.calledWith({
+					Filters: [
+						{
+							Name: 'instance-id',
+							Values: [old_instance_id]
+						}
+					]
+				})).to.be.true;
+
+				expect(mock_ec2.describeAddressesAsync.calledWith({
+					PublicIps: [pub_ip]
+				})).to.be.true;
+
+				expect(mock_ec2.disassociateAddressAsync.calledWith({
+					AssociationId: assoc_id
+				})).to.be.false;
+
+				expect(mock_ec2.associateAddressAsync.calledWith({
+					AllocationId: alloc_id,
+					InstanceId: new_instance_id
+				})).to.be.false;
+			});
+	});
+
+	it('should not replace an instance when failure to detach EIP from target', function () {
+		mock_ec2.disassociateAddressAsync = sandbox.stub().returns(
+			new Error("Something wrong")
+		);
+		return instance
+			.replace(['us-east-1'], 'old-instance', 'new-instance', true)
+			.then(function () {
+				expect(mock_elb.registerInstancesWithLoadBalancerAsync.calledWith({
+					Instances: [{InstanceId: new_instance_id}],
+					LoadBalancerName: 'lb'
+				})).to.be.true;
+
+				expect(mock_elb.deregisterInstancesFromLoadBalancerAsync.calledWith({
+					Instances: [{InstanceId: old_instance_id}],
+					LoadBalancerName: 'lb'
+				})).to.be.true;
+
+				expect(mock_elb.waitForAsync.calledWith(
+					'instanceInService',
+					{
+						LoadBalancerName: 'lb',
+						Instances: [
+							{
+								InstanceId: new_instance_id
+							}
+						]
+					}
+				)).to.be.true;
+
+				expect(mock_ec2.describeInstancesAsync.calledWith({
+					Filters: [
+						{
+							Name: 'instance-id',
+							Values: [old_instance_id]
+						}
+					]
+				})).to.be.true;
+
+				expect(mock_ec2.describeAddressesAsync.calledWith({
+					PublicIps: [pub_ip]
+				})).to.be.true;
+
+				expect(mock_ec2.disassociateAddressAsync.calledWith({
+					AssociationId: assoc_id
+				})).to.be.true;
+
+				expect(mock_ec2.associateAddressAsync.calledWith({
+					AllocationId: alloc_id,
+					InstanceId: new_instance_id
+				})).to.be.false;
+
+				expect(mock_ec2.terminateInstancesAsync.calledWith({
+					InstanceIds: [old_instance_id]
+				})).to.be.false;
+			});
+	});
+
+	it('should not replace an instance when failure to attach EIP to source', function () {
+		mock_ec2.associateAddressAsync = sandbox.stub().returns(
+			new Error("Something wrong")
+		);
+		return instance
+			.replace(['us-east-1'], 'old-instance', 'new-instance', true)
+			.then(function () {
+				expect(mock_elb.registerInstancesWithLoadBalancerAsync.calledWith({
+					Instances: [{InstanceId: new_instance_id}],
+					LoadBalancerName: 'lb'
+				})).to.be.true;
+
+				expect(mock_elb.deregisterInstancesFromLoadBalancerAsync.calledWith({
+					Instances: [{InstanceId: old_instance_id}],
+					LoadBalancerName: 'lb'
+				})).to.be.true;
+
+				expect(mock_elb.waitForAsync.calledWith(
+					'instanceInService',
+					{
+						LoadBalancerName: 'lb',
+						Instances: [
+							{
+								InstanceId: new_instance_id
+							}
+						]
+					}
+				)).to.be.true;
+
+				expect(mock_ec2.describeInstancesAsync.calledWith({
+					Filters: [
+						{
+							Name: 'instance-id',
+							Values: [old_instance_id]
+						}
+					]
+				})).to.be.true;
+
+				expect(mock_ec2.describeAddressesAsync.calledWith({
+					PublicIps: [pub_ip]
+				})).to.be.true;
+
+				expect(mock_ec2.disassociateAddressAsync.calledWith({
+					AssociationId: assoc_id
+				})).to.be.true;
+
+				expect(mock_ec2.associateAddressAsync.calledWith({
+					AllocationId: alloc_id,
+					InstanceId: new_instance_id
+				})).to.be.true;
+
+				expect(mock_ec2.terminateInstancesAsync.calledWith({
+					InstanceIds: [old_instance_id]
+				})).to.be.false;
 			});
 	});
 });

--- a/tst/api/instance/replace.test.js
+++ b/tst/api/instance/replace.test.js
@@ -1,7 +1,13 @@
 'use strict';
 
 const Promise = require('bluebird');
-const expect = require('chai').expect;
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+
+chai.use(chaiAsPromised);
+
+const expect = chai.expect;
+
 const sinon = require('sinon');
 
 const AWSProvider = require('../../../src/api/aws_provider');
@@ -99,21 +105,21 @@ describe('instance replace', function () {
 		sandbox.restore();
 	});
 
-	it('should replace an instance when associating an elastic IP successfully', function () {
+	it('replaces an instance when associating an elastic IP successfully', function () {
 		return instance
 			.replace(['us-east-1'], 'old-instance', 'new-instance', true)
 			.then(function () {
-				expect(mock_elb.registerInstancesWithLoadBalancerAsync.calledWith({
+				expect(mock_elb.registerInstancesWithLoadBalancerAsync).to.have.been.calledWith({
 					Instances: [{InstanceId: new_instance_id}],
 					LoadBalancerName: 'lb'
-				})).to.be.true;
+				});
 
-				expect(mock_elb.deregisterInstancesFromLoadBalancerAsync.calledWith({
+				expect(mock_elb.deregisterInstancesFromLoadBalancerAsync).to.have.been.calledWith({
 					Instances: [{InstanceId: old_instance_id}],
 					LoadBalancerName: 'lb'
-				})).to.be.true;
+				});
 
-				expect(mock_elb.waitForAsync.calledWith(
+				expect(mock_elb.waitForAsync).to.have.been.calledWith(
 					'instanceInService',
 					{
 						LoadBalancerName: 'lb',
@@ -123,47 +129,47 @@ describe('instance replace', function () {
 							}
 						]
 					}
-				)).to.be.true;
+				);
 
-				expect(mock_ec2.describeInstancesAsync.calledWith({
+				expect(mock_ec2.describeInstancesAsync).to.have.been.calledWith({
 					Filters: [
 						{
 							Name: 'instance-id',
 							Values: [old_instance_id]
 						}
 					]
-				})).to.be.true;
+				});
 
-				expect(mock_ec2.describeAddressesAsync.calledWith({
+				expect(mock_ec2.describeAddressesAsync).to.have.been.calledWith({
 					PublicIps: [pub_ip]
-				})).to.be.true;
+				});
 
-				expect(mock_ec2.disassociateAddressAsync.calledWith({
+				expect(mock_ec2.disassociateAddressAsync).to.have.been.calledWith({
 					AssociationId: assoc_id
-				})).to.be.true;
+				});
 
-				expect(mock_ec2.associateAddressAsync.calledWith({
+				expect(mock_ec2.associateAddressAsync).to.have.been.calledWith({
 					AllocationId: alloc_id,
 					InstanceId: new_instance_id
-				})).to.be.true;
+				});
 			});
 	});
 
-	it('should replace an instance when not association an elastic IP successfully', function () {
+	it('replaces an instance when not association an elastic IP successfully', function () {
 		return instance
 			.replace(['us-east-1'], 'old-instance', 'new-instance', false)
 			.then(function () {
-				expect(mock_elb.registerInstancesWithLoadBalancerAsync.calledWith({
+				expect(mock_elb.registerInstancesWithLoadBalancerAsync).to.have.been.calledWith({
 					Instances: [{InstanceId: new_instance_id}],
 					LoadBalancerName: 'lb'
-				})).to.be.true;
+				});
 
-				expect(mock_elb.deregisterInstancesFromLoadBalancerAsync.calledWith({
+				expect(mock_elb.deregisterInstancesFromLoadBalancerAsync).to.have.been.calledWith({
 					Instances: [{InstanceId: old_instance_id}],
 					LoadBalancerName: 'lb'
-				})).to.be.true;
+				});
 
-				expect(mock_elb.waitForAsync.calledWith(
+				expect(mock_elb.waitForAsync).to.have.been.calledWith(
 					'instanceInService',
 					{
 						LoadBalancerName: 'lb',
@@ -173,50 +179,36 @@ describe('instance replace', function () {
 							}
 						]
 					}
-				)).to.be.true;
+				);
 
-				expect(mock_ec2.describeInstancesAsync.calledWith({
-					Filters: [
-						{
-							Name: 'instance-id',
-							Values: [old_instance_id]
-						}
-					]
-				})).to.be.false;
+				expect(mock_ec2.describeInstancesAsync).to.not.have.been.called;
 
-				expect(mock_ec2.describeAddressesAsync.calledWith({
-					PublicIps: [pub_ip]
-				})).to.be.false;
+				expect(mock_ec2.describeAddressesAsync).to.not.have.been.called;
 
-				expect(mock_ec2.disassociateAddressAsync.calledWith({
-					AssociationId: assoc_id
-				})).to.be.false;
+				expect(mock_ec2.disassociateAddressAsync).to.not.have.been.called;
 
-				expect(mock_ec2.associateAddressAsync.calledWith({
-					AllocationId: alloc_id,
-					InstanceId: new_instance_id
-				})).to.be.false;
+				expect(mock_ec2.associateAddressAsync).to.not.have.been.called;
 			});
 	});
 
-	it('should replace an instance when associate elastic IP but instance description not found', function () {
+	it('replaces an instance when associate elastic IP but instance description not found', function () {
 		mock_ec2.describeInstancesAsync = sandbox.stub().returns(
 			Promise.reject(new Error("Something wrong"))
 		);
 		return instance
 			.replace(['us-east-1'], 'old-instance', 'new-instance', true)
 			.then(function () {
-				expect(mock_elb.registerInstancesWithLoadBalancerAsync.calledWith({
+				expect(mock_elb.registerInstancesWithLoadBalancerAsync).to.have.been.calledWith({
 					Instances: [{InstanceId: new_instance_id}],
 					LoadBalancerName: 'lb'
-				})).to.be.true;
+				});
 
-				expect(mock_elb.deregisterInstancesFromLoadBalancerAsync.calledWith({
+				expect(mock_elb.deregisterInstancesFromLoadBalancerAsync).to.have.been.calledWith({
 					Instances: [{InstanceId: old_instance_id}],
 					LoadBalancerName: 'lb'
-				})).to.be.true;
+				});
 
-				expect(mock_elb.waitForAsync.calledWith(
+				expect(mock_elb.waitForAsync).to.have.been.calledWith(
 					'instanceInService',
 					{
 						LoadBalancerName: 'lb',
@@ -226,50 +218,43 @@ describe('instance replace', function () {
 							}
 						]
 					}
-				)).to.be.true;
+				);
 
-				expect(mock_ec2.describeInstancesAsync.calledWith({
+				expect(mock_ec2.describeInstancesAsync).to.have.been.calledWith({
 					Filters: [
 						{
 							Name: 'instance-id',
 							Values: [old_instance_id]
 						}
 					]
-				})).to.be.true;
+				});
 
-				expect(mock_ec2.describeAddressesAsync.calledWith({
-					PublicIps: [pub_ip]
-				})).to.be.false;
+				expect(mock_ec2.describeAddressesAsync).to.not.have.been.called;
 
-				expect(mock_ec2.disassociateAddressAsync.calledWith({
-					AssociationId: assoc_id
-				})).to.be.false;
+				expect(mock_ec2.disassociateAddressAsync).to.not.have.been.called;
 
-				expect(mock_ec2.associateAddressAsync.calledWith({
-					AllocationId: alloc_id,
-					InstanceId: new_instance_id
-				})).to.be.false;
+				expect(mock_ec2.associateAddressAsync).to.not.have.been.called;
 			});
 	});
 
-	it('should replace an instance when associate elastic IP but EIP not found', function () {
+	it('replaces an instance when associate elastic IP but EIP not found', function () {
 		mock_ec2.describeAddressesAsync = sandbox.stub().returns(
 			Promise.reject(new Error("Something wrong"))
 		);
 		return instance
 			.replace(['us-east-1'], 'old-instance', 'new-instance', true)
 			.then(function () {
-				expect(mock_elb.registerInstancesWithLoadBalancerAsync.calledWith({
+				expect(mock_elb.registerInstancesWithLoadBalancerAsync).to.have.been.calledWith({
 					Instances: [{InstanceId: new_instance_id}],
 					LoadBalancerName: 'lb'
-				})).to.be.true;
+				});
 
-				expect(mock_elb.deregisterInstancesFromLoadBalancerAsync.calledWith({
+				expect(mock_elb.deregisterInstancesFromLoadBalancerAsync).to.have.been.calledWith({
 					Instances: [{InstanceId: old_instance_id}],
 					LoadBalancerName: 'lb'
-				})).to.be.true;
+				});
 
-				expect(mock_elb.waitForAsync.calledWith(
+				expect(mock_elb.waitForAsync).to.have.been.calledWith(
 					'instanceInService',
 					{
 						LoadBalancerName: 'lb',
@@ -279,50 +264,46 @@ describe('instance replace', function () {
 							}
 						]
 					}
-				)).to.be.true;
+				);
 
-				expect(mock_ec2.describeInstancesAsync.calledWith({
+				expect(mock_ec2.describeInstancesAsync).to.have.been.calledWith({
 					Filters: [
 						{
 							Name: 'instance-id',
 							Values: [old_instance_id]
 						}
 					]
-				})).to.be.true;
+				});
 
-				expect(mock_ec2.describeAddressesAsync.calledWith({
+				expect(mock_ec2.describeAddressesAsync).to.have.been.calledWith({
 					PublicIps: [pub_ip]
-				})).to.be.true;
+				});
 
-				expect(mock_ec2.disassociateAddressAsync.calledWith({
-					AssociationId: assoc_id
-				})).to.be.false;
+				expect(mock_ec2.disassociateAddressAsync).to.not.have.been.called;
 
-				expect(mock_ec2.associateAddressAsync.calledWith({
-					AllocationId: alloc_id,
-					InstanceId: new_instance_id
-				})).to.be.false;
+				expect(mock_ec2.associateAddressAsync).to.not.have.been.called;
 			});
 	});
 
-	it('should not replace an instance when failure to detach EIP from target', function () {
+	it.only('does not replace an instance when failure to detach EIP from target', function () {
+		let rejection_msg = "Something wrong";
 		mock_ec2.disassociateAddressAsync = sandbox.stub().returns(
-			new Error("Something wrong")
+			Promise.reject(new Error(rejection_msg))
 		);
 		return instance
 			.replace(['us-east-1'], 'old-instance', 'new-instance', true)
 			.then(function () {
-				expect(mock_elb.registerInstancesWithLoadBalancerAsync.calledWith({
+				expect(mock_elb.registerInstancesWithLoadBalancerAsync).to.have.been.calledWith({
 					Instances: [{InstanceId: new_instance_id}],
 					LoadBalancerName: 'lb'
-				})).to.be.true;
+				});
 
-				expect(mock_elb.deregisterInstancesFromLoadBalancerAsync.calledWith({
+				expect(mock_elb.deregisterInstancesFromLoadBalancerAsync).to.have.been.calledWith({
 					Instances: [{InstanceId: old_instance_id}],
 					LoadBalancerName: 'lb'
-				})).to.be.true;
+				});
 
-				expect(mock_elb.waitForAsync.calledWith(
+				expect(mock_elb.waitForAsync).to.have.been.calledWith(
 					'instanceInService',
 					{
 						LoadBalancerName: 'lb',
@@ -332,39 +313,32 @@ describe('instance replace', function () {
 							}
 						]
 					}
-				)).to.be.true;
+				);
 
-				expect(mock_ec2.describeInstancesAsync.calledWith({
+				expect(mock_ec2.describeInstancesAsync).to.have.been.calledWith({
 					Filters: [
 						{
 							Name: 'instance-id',
 							Values: [old_instance_id]
 						}
 					]
-				})).to.be.true;
+				});
 
-				expect(mock_ec2.describeAddressesAsync.calledWith({
+				expect(mock_ec2.describeAddressesAsync).to.have.been.calledWith({
 					PublicIps: [pub_ip]
-				})).to.be.true;
+				});
 
-				expect(mock_ec2.disassociateAddressAsync.calledWith({
-					AssociationId: assoc_id
-				})).to.be.true;
+				expect(mock_ec2.disassociateAddressAsync).to.be.eventually.rejectedWith(Error, rejection_msg);
 
-				expect(mock_ec2.associateAddressAsync.calledWith({
-					AllocationId: alloc_id,
-					InstanceId: new_instance_id
-				})).to.be.false;
+				expect(mock_ec2.associateAddressAsync).to.not.have.been.called;
 
-				expect(mock_ec2.terminateInstancesAsync.calledWith({
-					InstanceIds: [old_instance_id]
-				})).to.be.false;
+				expect(mock_ec2.terminateInstancesAsync).to.not.have.been.called;
 			});
 	});
 
 	it('should not replace an instance when failure to attach EIP to source', function () {
 		mock_ec2.associateAddressAsync = sandbox.stub().returns(
-			new Error("Something wrong")
+			Promise.reject(new Error("Something wrong"))
 		);
 		return instance
 			.replace(['us-east-1'], 'old-instance', 'new-instance', true)


### PR DESCRIPTION
- On replace allow the setting "assign-elastic-ip"
- If this value is 'true' then it will attempt to detach the elastic IP from the target and reattach it to the source
- If this value is 'true' and the target does not have an EIP it will return an error