### PR TITLE
[jb/elastic-ips-2.W-4956474] Add EIP to instance create

### DIFF
--- a/src/api/ami/create.js
+++ b/src/api/ami/create.js
@@ -67,7 +67,7 @@ function create(regions, ami_name, vpc, ami, i_type, key_name, sg, iam, ud_files
 	let spinup_complete_ud = _gen_spinup_complete_ud(regions[0]);
 	let tags = [`Name=nemesys-create-ami::${ami_name}`];
 	// create in first region, then copy to others
-	return create_instance([regions[0]], vpc, ami, i_type, key_name, sg, iam, ud_files, rud_files, spinup_complete_ud, disks, az, tags)
+	return create_instance([regions[0]], vpc, ami, i_type, key_name, sg, iam, ud_files, rud_files, spinup_complete_ud, disks, az, tags, null, null, false, [], false)
 	.then(function(instance_ids){ //create_instance is for many regions, so result is an array of ids
 		Logger.info(`${regions[0]}: instance (${instance_ids[0]}) created`);
 		return _do_create(regions[0], instance_ids[0], regions.slice(1), ami_name, disks, preserve_instance);

--- a/src/api/ami/create.js
+++ b/src/api/ami/create.js
@@ -59,12 +59,8 @@ function _do_create(create_region, instance_id, copy_regions, ami_name, disks, p
 	});
 }
 
-function _gen_spinup_complete_ud(region) {
-	return `\naws ec2 create-tags --region ${region} --resources \`curl http:\/\/169.254.169.254\/latest\/meta-data\/instance-id\` --tags Key=Spinup,Value=complete\n`;
-}
-
 function create(regions, ami_name, vpc, ami, i_type, key_name, sg, iam, ud_files, rud_files, disks, az, preserve_instance){
-	let spinup_complete_ud = _gen_spinup_complete_ud(regions[0]);
+	let spinup_complete_ud = health_check.gen_spinup_complete_userdata(regions[0]);
 	let tags = [`Name=nemesys-create-ami::${ami_name}`];
 	// create in first region, then copy to others
 	return create_instance([regions[0]], vpc, ami, i_type, key_name, sg, iam, ud_files, rud_files, spinup_complete_ud, disks, az, tags, null, null, false, [], false)

--- a/src/api/aws_util.js
+++ b/src/api/aws_util.js
@@ -96,7 +96,7 @@ function _get_ami_id(region, ami_name) {
 			}
 		]
 	};
-return AWSProvider.get_ec2(region).describeImagesAsync(params)
+	return AWSProvider.get_ec2(region).describeImagesAsync(params)
 	.then(function(data){
 		if(!data.hasOwnProperty('Images') || !data.Images.length) {
 			return null;
@@ -304,6 +304,71 @@ function _get_eni_id(region, vpc, az, eni_name) {
 	});
 }
 
+
+// uses waitFor to poll an instance for a specific state
+// state can be any state accepted by waitForAysnc
+// https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/EC2.html#waitFor-property
+function _wait_until_status(region, instanceId, state) {
+	return AWSProvider
+		.get_ec2(region)
+		.waitForAsync(state, {
+			InstanceIds: [instanceId]
+		})
+		.then(function (data) {
+			const instance = data.Reservations[0].Instances[0];
+
+			if (state == 'instanceRunning' && instance.State.Name !== 'running') {
+				throw new Error(instance.StateReason.Message);
+			}
+
+			return instance.InstanceId;
+
+		});
+}
+
+function _attach_elastic_ip(region, source_instance_id, alloc_id) {
+	let params = {
+		AllocationId: alloc_id,
+		InstanceId: source_instance_id
+	};
+
+	return AWSProvider
+		.get_ec2(region)
+		.associateAddressAsync(params);
+}
+
+function _detach_elastic_ip(region, assoc_id) {
+	let params = {
+		AssociationId: assoc_id
+	};
+
+	return AWSProvider
+		.get_ec2(region)
+		.disassociateAddressAsync(params);
+}
+
+function _get_eip_info(region, pub_address) {
+	let params = {
+		PublicIps: [pub_address]
+	};
+	return AWSProvider
+		.get_ec2(region)
+		.describeAddressesAsync(params)
+		.then(data => {
+			if (data && data.Addresses && data.Addresses.length) {
+				for (let address of data.Addresses) {
+					if (address.AllocationId) {
+						return {
+							alloc_id: address.AllocationId,
+							assoc_id: address.AssociationId  // This may not be set, which is OK
+						};
+					}
+				}
+			}
+		});
+}
+
+
 exports.get_asg = _get_asg;
 exports.get_sg_id = _get_sg_id;
 exports.get_vpc_id = _get_vpc_id;
@@ -318,3 +383,7 @@ exports.get_instance_by_name = _get_instance_by_name;
 exports.get_network_interface = _get_network_interface;
 exports.get_eni_id = _get_eni_id;
 exports.get_ud_files = _get_ud_files;
+exports.wait_until_status = _wait_until_status;
+exports.attach_elastic_ip = _attach_elastic_ip;
+exports.detach_elastic_ip = _detach_elastic_ip;
+exports.get_eip_info = _get_eip_info;

--- a/src/api/aws_util.js
+++ b/src/api/aws_util.js
@@ -304,28 +304,6 @@ function _get_eni_id(region, vpc, az, eni_name) {
 	});
 }
 
-
-// uses waitFor to poll an instance for a specific state
-// state can be any state accepted by waitForAysnc
-// https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/EC2.html#waitFor-property
-function _wait_until_status(region, instanceId, state) {
-	return AWSProvider
-		.get_ec2(region)
-		.waitForAsync(state, {
-			InstanceIds: [instanceId]
-		})
-		.then(function (data) {
-			const instance = data.Reservations[0].Instances[0];
-
-			if (state == 'instanceRunning' && instance.State.Name !== 'running') {
-				throw new Error(instance.StateReason.Message);
-			}
-
-			return instance.InstanceId;
-
-		});
-}
-
 function _attach_elastic_ip(region, source_instance_id, alloc_id) {
 	let params = {
 		AllocationId: alloc_id,
@@ -383,7 +361,6 @@ exports.get_instance_by_name = _get_instance_by_name;
 exports.get_network_interface = _get_network_interface;
 exports.get_eni_id = _get_eni_id;
 exports.get_ud_files = _get_ud_files;
-exports.wait_until_status = _wait_until_status;
 exports.attach_elastic_ip = _attach_elastic_ip;
 exports.detach_elastic_ip = _detach_elastic_ip;
 exports.get_eip_info = _get_eip_info;

--- a/src/api/health_checks.js
+++ b/src/api/health_checks.js
@@ -46,6 +46,10 @@ function _wait_until_healthy(region, lbName, instanceId) {
 		});
 }
 
+function _gen_spinup_complete_userdata(region) {
+	return `\naws ec2 create-tags --region ${region} --resources \`curl http:\/\/169.254.169.254\/latest\/meta-data\/instance-id\` --tags Key=Spinup,Value=complete\n`;
+}
+
 function _is_tag_present(tags, key, value) {
 	if(tags && tags.length > 0) {
 		for(let i=0; i<tags.length; i++) {
@@ -76,4 +80,5 @@ function _wait_for_spinup_complete(region, instance_id) {
 
 exports.wait_until_status = _wait_until_status;
 exports.wait_until_healthy = _wait_until_healthy;
+exports.gen_spinup_complete_userdata = _gen_spinup_complete_userdata;
 exports.wait_for_spinup_complete = _wait_for_spinup_complete;

--- a/src/api/instance/create.js
+++ b/src/api/instance/create.js
@@ -7,7 +7,7 @@ const AWSUtil = require('../aws_util');
 const AWSProvider = require('../aws_provider');
 const health_check = require('../health_checks');
 
-function _do_create(region, vpc, ami, i_type, key_name, sg, iam, ud_files, raw_ud_string, disks, az, tags, eni_name, env_vars, ebs_opt) {
+function _do_create(region, vpc, ami, i_type, key_name, sg, iam, ud_files, raw_ud_string, disks, az, tags, eni_name, env_vars, ebs_opt, elastic_ip, reassociate_eip) {
 	let EC2 = AWSProvider.get_ec2(region);
 	return BB.all([
 		AWSUtil.get_ami_id(region, ami),
@@ -40,9 +40,8 @@ function _do_create(region, vpc, ami, i_type, key_name, sg, iam, ud_files, raw_u
 	})
 	.then(function(data){
 		return health_check.wait_until_status(region, data.Instances[0].InstanceId, 'instanceExists');
-	})
-	.then(function(instance_id){
-		if(tags && tags.length > 0) {
+	}).then(instance_id => {
+		if (tags && tags.length > 0) {
 			Logger.info(`${region}: instance ${instance_id} is ready, applying tags`);
 			tags = tags.map(function(tag_str){
 				let kv = tag_str.split('=');
@@ -58,17 +57,55 @@ function _do_create(region, vpc, ami, i_type, key_name, sg, iam, ud_files, raw_u
 		} else {
 			return instance_id;
 		}
+	}).then(instance_id => {
+		// Only after tags are finished should we reassociate the elastic IP to the new instance
+		if (elastic_ip) {
+			Logger.info(`${region}: getting info for EIP ${elastic_ip}`);
+			return AWSUtil.get_eip_info(region, elastic_ip).then(eip_hash => {
+					if (elastic_ip && eip_hash) {
+						if (eip_hash.assoc_id) {
+							Logger.info(`${region}: EIP is associated with assoc. ID: ${eip_hash.assoc_id}`);
+							if (reassociate_eip) {
+								Logger.info(`${region}: Detaching EIP`);
+								return AWSUtil.detach_elastic_ip(region, eip_hash.assoc_id)
+									.then(() => {
+										return eip_hash.alloc_id;
+									});
+							} else {
+								// Will return nothing, skipping the next step
+								Logger.info(`${region}: EIP is associated already but reassociate-eip is false, skipping`);
+							}
+						} else if (eip_hash.alloc_id) {
+							Logger.info(`${region}: EIP not currently associated`);
+							return eip_hash.alloc_id;
+						}
+					}
+				})
+				.then(alloc_id => {
+					if (elastic_ip && alloc_id) {
+						Logger.info(`${region}: Attach EIP to ${instance_id}`);
+						return AWSUtil.attach_elastic_ip(region, instance_id, alloc_id)
+							.then(() => {
+								return instance_id;
+							});
+					} else {
+						return instance_id;
+					}
+				});
+		} else {
+			return instance_id;
+		}
 	});
 }
 
-function create(regions, vpc, ami, i_type, key_name, sg, iam, ud_files, rud_files, raw_ud_string, disks, az, tags, eni_name, env_vars, ebs_opt){
+function create(regions, vpc, ami, i_type, key_name, sg, iam, ud_files, rud_files, raw_ud_string, disks, az, tags, eni_name, env_vars, ebs_opt, elastic_ips, reassociate_eip){
 	if( !(az.length === 1 || az.length === regions.length) ) {
 		return Promise.reject(new Error(`Must pass either one AZ or one per region. Found ${az.length} for ${regions.length} region(s)`));
 	}
 	let region_promises = regions.map(function(region, idx){
 		let zone = az.length == regions.length ? az[idx] : az[0];
 		let userdata_files = AWSUtil.get_ud_files(ud_files, rud_files, idx);
-		return _do_create(region, vpc, ami, i_type, key_name, sg, iam, userdata_files, raw_ud_string, disks, zone, tags, eni_name, env_vars, ebs_opt);
+		return _do_create(region, vpc, ami, i_type, key_name, sg, iam, userdata_files, raw_ud_string, disks, zone, tags, eni_name, env_vars, ebs_opt, elastic_ips[idx], reassociate_eip);
 	});
 	return BB.all(region_promises);
 }

--- a/src/api/instance/create.js
+++ b/src/api/instance/create.js
@@ -106,6 +106,7 @@ function create(regions, vpc, ami, i_type, key_name, sg, iam, ud_files, rud_file
 	if( !(az.length === 1 || az.length === regions.length) ) {
 		return Promise.reject(new Error(`Must pass either one AZ or one per region. Found ${az.length} for ${regions.length} region(s)`));
 	}
+	console.log('REASSOCIATE EIP?', reassociate_eip);
 	let region_promises = regions.map(function(region, idx){
 		if(elastic_ips.length && reassociate_eip) {
 			let spinup_complete_ud = health_check.gen_spinup_complete_userdata(region);

--- a/src/api/instance/create.js
+++ b/src/api/instance/create.js
@@ -106,7 +106,6 @@ function create(regions, vpc, ami, i_type, key_name, sg, iam, ud_files, rud_file
 	if( !(az.length === 1 || az.length === regions.length) ) {
 		return Promise.reject(new Error(`Must pass either one AZ or one per region. Found ${az.length} for ${regions.length} region(s)`));
 	}
-	console.log('REASSOCIATE EIP?', reassociate_eip);
 	let region_promises = regions.map(function(region, idx){
 		if(elastic_ips.length && reassociate_eip) {
 			let spinup_complete_ud = health_check.gen_spinup_complete_userdata(region);

--- a/src/api/instance/create.js
+++ b/src/api/instance/create.js
@@ -66,7 +66,7 @@ function _do_create(region, vpc, ami, i_type, key_name, sg, iam, ud_files, raw_u
 						if (eip_hash.assoc_id) {
 							Logger.info(`${region}: EIP is associated with assoc. ID: ${eip_hash.assoc_id}`);
 							if (reassociate_eip) {
-								// Before we detach the existin EIP we should be sure that the new instance is good to go
+								// Before we detach the existing EIP we should be sure that the new instance is good to go
 								return health_check.wait_for_spinup_complete(region, instance_id)
 									.then(() => {
 										Logger.info(`${region}: Detaching EIP`);

--- a/src/cli/arg_handler.js
+++ b/src/cli/arg_handler.js
@@ -246,8 +246,7 @@ function _handle_replace(cmd) {
 			nemesys.instance.replace(
 				cmd.opts['regions'],
 				cmd.opts['target'],
-				cmd.opts['source'],
-				cmd.opts['reassociate-eip']
+				cmd.opts['source']
 			).then(function () {
 				Logger.info('replace complete');
 				process.exit(0);

--- a/src/cli/arg_handler.js
+++ b/src/cli/arg_handler.js
@@ -114,7 +114,7 @@ function _handle_create(cmd) {
 				cmd.opts['network-interface'],
 				cmd.opts['env'],
 				cmd.opts['optimize-ebs'],
-				cmd.opts['elastic-ips'], // The elastic IPs to use (one per region).
+				cmd.opts['elastic-ips'], // The elastic IPs to use (one per AZ/Region).
 				cmd.opts['reassociate-eip'] // You need to be explicit in what this is going to do, if this is false we'll skip
 			).then(function(){
 				Logger.info('created instance');

--- a/src/cli/arg_handler.js
+++ b/src/cli/arg_handler.js
@@ -113,7 +113,9 @@ function _handle_create(cmd) {
 				cmd.opts['tags'],
 				cmd.opts['network-interface'],
 				cmd.opts['env'],
-				cmd.opts['optimize-ebs']
+				cmd.opts['optimize-ebs'],
+				cmd.opts['elastic-ips'], // The elastic IPs to use (one per region).
+				cmd.opts['reassociate-eip'] // You need to be explicit in what this is going to do, if this is false we'll skip
 			).then(function(){
 				Logger.info('created instance');
 				process.exit(0);
@@ -245,7 +247,7 @@ function _handle_replace(cmd) {
 				cmd.opts['regions'],
 				cmd.opts['target'],
 				cmd.opts['source'],
-				cmd.opts['assign-elastic-ip']
+				cmd.opts['reassociate-eip']
 			).then(function () {
 				Logger.info('replace complete');
 				process.exit(0);

--- a/src/cli/parse_args.js
+++ b/src/cli/parse_args.js
@@ -289,14 +289,15 @@ function parse_args (args) {
 						.option('optimize-ebs', {
 							describe: 'Use EBS optimization'
 						})
-						.option('elastic-ips', {
+						.option('e', {
+							alias:    'elastic-ips',
 							describe: 'The elastic IPs to use (per AZ/Region). We won\'t detach it if in use unless reassociate-eip is true',
 							array:    true
 						})
-						.option('reassociate-eip', {
+						.option('p', {
+							alias:    'reassociate-eip',
 							describe: 'If true we\'ll detach the EIP from the existing instance.',
-							type: 'boolean',
-							default: false
+							type:     'boolean'
 						})
 						.example('');
 				})

--- a/src/cli/parse_args.js
+++ b/src/cli/parse_args.js
@@ -290,7 +290,7 @@ function parse_args (args) {
 							describe: 'Use EBS optimization'
 						})
 						.option('elastic-ips', {
-							describe: 'The elastic IPs to use (per region). We won\'t detach it if in use unless reassociate-eip is true',
+							describe: 'The elastic IPs to use (per AZ/Region). We won\'t detach it if in use unless reassociate-eip is true',
 							array:    true
 						})
 						.option('reassociate-eip', {

--- a/src/cli/parse_args.js
+++ b/src/cli/parse_args.js
@@ -290,7 +290,7 @@ function parse_args (args) {
 							describe: 'Use EBS optimization'
 						})
 						.option('elastic-ips', {
-							describe: 'The elastic IPs to use (per region). We won\'t detach it if in use unless reassociate-eip is true'
+							describe: 'The elastic IPs to use (per region). We won\'t detach it if in use unless reassociate-eip is true',
 							array:    true
 						})
 						.option('reassociate-eip', {

--- a/src/cli/parse_args.js
+++ b/src/cli/parse_args.js
@@ -406,12 +406,6 @@ function parse_args (args) {
 							describe: 'Target instance name'
 						})
 						.option('i', ingress_rules_opt)
-						.option('e', {
-							alias: 'reassociate-eip',
-							describe: 'Boolean, whether to transfer an elastic IP from the old box to the new; defaults to true',
-							type: 'boolean',
-							default: true
-						})
 						.example('nemesys replace instance -s source-instance-name -t target-instance-name -r us-east-1', 'Replaces target instance with src instance')
 						.help('h')
 						.alias('h', 'help');

--- a/src/cli/parse_args.js
+++ b/src/cli/parse_args.js
@@ -289,7 +289,15 @@ function parse_args (args) {
 						.option('optimize-ebs', {
 							describe: 'Use EBS optimization'
 						})
-
+						.option('elastic-ips', {
+							describe: 'The elastic IPs to use (per region). We won\'t detach it if in use unless reassociate-eip is true'
+							array:    true
+						})
+						.option('reassociate-eip', {
+							describe: 'If true we\'ll detach the EIP from the existing instance.',
+							type: 'boolean',
+							default: false
+						})
 						.example('');
 				})
 
@@ -399,7 +407,7 @@ function parse_args (args) {
 						})
 						.option('i', ingress_rules_opt)
 						.option('e', {
-							alias: 'assign-elastic-ip',
+							alias: 'reassociate-eip',
 							describe: 'Boolean, whether to transfer an elastic IP from the old box to the new; defaults to true',
 							type: 'boolean',
 							default: true

--- a/src/cli/parse_args.js
+++ b/src/cli/parse_args.js
@@ -297,7 +297,8 @@ function parse_args (args) {
 						.option('p', {
 							alias:    'reassociate-eip',
 							describe: 'If true we\'ll detach the EIP from the existing instance.',
-							type:     'boolean'
+							type:     'boolean',
+							default:  undefined
 						})
 						.example('');
 				})

--- a/tst/api/instance/create.test.js
+++ b/tst/api/instance/create.test.js
@@ -7,11 +7,21 @@ const sinon = require('sinon');
 const AWSProvider = require('../../../src/api/aws_provider');
 const AWSUtil = require('../../../src/api/aws_util');
 const instance = require('../../../src/api/instance');
+const health_check = require('../../../src/api/health_checks');
 
 describe('instance create', function () {
 	let sandbox, mock_ec2, expected_run_args;
+	let region, tag, tag_key, alloc_id, assoc_id, pub_ip, instance_id;
 
 	beforeEach(function () {
+		region = 'us-east-1';
+		tag = 'tag1=val1';
+		tag_key = {Key: 'tag1', Value: 'val1'};
+		alloc_id = 'aloc123';
+		assoc_id = 'assoc123';
+		pub_ip = '999.999.999.999';
+		instance_id = '123';
+
 		sandbox = sinon.sandbox.create();
 		sandbox.stub(AWSUtil, 'get_ami_id', (region, ami_name) => Promise.resolve(
 			ami_name
@@ -23,11 +33,13 @@ describe('instance create', function () {
 			eni_name
 		));
 
+		sandbox.stub(health_check, 'wait_until_status').returns(Promise.resolve(instance_id));
+
 		mock_ec2 = {
 			runInstancesAsync: sandbox.stub().returns(
 				Promise.resolve({
 					Instances: [
-						{InstanceId: '123'}
+						{InstanceId: instance_id}
 					]
 				})
 			),
@@ -63,7 +75,7 @@ describe('instance create', function () {
 						{
 							Instances: [
 								{
-									InstanceId: '123',
+									InstanceId: instance_id,
 									State: {
 										Name: 'running'
 									}
@@ -72,6 +84,20 @@ describe('instance create', function () {
 						}
 					]
 				})
+			),
+			describeAddressesAsync: sandbox.stub().returns(
+				Promise.resolve({
+					Addresses: [{
+						AllocationId: alloc_id,
+						AssociationId: assoc_id
+					}]
+				})
+			),
+			disassociateAddressAsync: sandbox.stub().returns(
+				Promise.resolve()
+			),
+			associateAddressAsync: sandbox.stub().returns(
+				Promise.resolve()
 			)
 		};
 		expected_run_args = {
@@ -98,18 +124,142 @@ describe('instance create', function () {
 		sandbox.restore();
 	});
 
-	it('should create an instance', function () {
+	it('creates an instance with no elastic ip', function () {
 		return instance
-			.create(['us-east-1'], null, 'image_id', null, null, null, 'iam', null, null, null, null, ['e'], null, 'fake-network-interface-id', null, null)
+			.create([region], null, 'image_id', null, null, null, 'iam', null, null, null, null, ['e'], null, 'fake-network-interface-id', null, null, null, false)
 			.then(function (result) {
-				expect(mock_ec2.runInstancesAsync.calledWith(expected_run_args)).to.be.true;
+				expect(mock_ec2.runInstancesAsync).to.have.been.calledWith(expected_run_args);
 
-				expect(mock_ec2.waitForAsync.calledWith('instanceExists', {
-						InstanceIds: ['123']
-				})).to.be.true;
+				expect(health_check.wait_until_status).to.have.been.calledWith(region, instance_id, 'instanceExists');
 
-				expect(result).eql(['123']);
+				expect(mock_ec2.describeAddressesAsync).to.have.not.been.called;
+
+				expect(mock_ec2.disassociateAddressAsync).to.have.not.been.called;
+
+				expect(mock_ec2.associateAddressAsync).to.have.not.been.called;
+
+				expect(result).eql([instance_id]);
 			});
 	});
 
+	it('creates an instance with an elastic ip when reassociate is true, and detaching and attaching succeeds', function () {
+		return instance
+			.create([region], null, 'image_id', null, null, null, 'iam', null, null, null, null, ['e'], [tag], 'fake-network-interface-id', null, null, pub_ip, true)
+			.then(function (result) {
+				expect(mock_ec2.runInstancesAsync).to.have.been.calledWith(expected_run_args);
+
+				expect(health_check.wait_until_status).to.have.been.calledWith(region, instance_id, 'instanceExists');
+
+				expect(mock_ec2.createTagsAsync).to.be.calledWith({
+					Resources: [instance_id],
+					Tags: [tag_key]
+				});
+
+				expect(mock_ec2.describeAddressesAsync).to.have.been.calledWith({
+					PublicIps: [pub_ip]
+				});
+
+				expect(mock_ec2.disassociateAddressAsync).to.have.been.calledWith({
+					AssociationId: assoc_id
+				});
+
+				expect(mock_ec2.associateAddressAsync).to.have.been.calledWith({
+					AllocationId: alloc_id,
+					InstanceId: instance_id
+				});
+
+				expect(result).eql([instance_id]);
+			});
+	});
+
+	it('creates an instance without an elastic IP when reassociate is false and an EIP is already attached', function () {
+		return instance
+			.create([region], null, 'image_id', null, null, null, 'iam', null, null, null, null, ['e'], [tag], 'fake-network-interface-id', null, null, pub_ip, false)
+			.then(function (result) {
+				expect(mock_ec2.runInstancesAsync).to.have.been.calledWith(expected_run_args);
+
+				expect(health_check.wait_until_status).to.have.been.calledWith(region, instance_id, 'instanceExists');
+
+				expect(mock_ec2.createTagsAsync).to.have.been.calledWith({
+					Resources: [instance_id],
+					Tags: [tag_key]
+				});
+
+				expect(mock_ec2.describeAddressesAsync).to.have.been.calledWith({
+					PublicIps: [pub_ip]
+				});
+
+				expect(mock_ec2.disassociateAddressAsync).to.have.not.been.called;
+
+				expect(mock_ec2.associateAddressAsync).to.have.not.been.called;
+
+				expect(result).eql([instance_id]);
+			});
+	});
+
+	it('creates an instance with an elastic ip when reassociate is true, nothing to detach, and attaching succeeds', function () {
+		mock_ec2.describeAddressesAsync = sandbox.stub().returns(
+			Promise.resolve({
+				Addresses: [{
+					AllocationId: alloc_id,
+					AssociationId: null
+				}]
+			})
+		);
+		return instance
+			.create([region], null, 'image_id', null, null, null, 'iam', null, null, null, null, ['e'], [tag], 'fake-network-interface-id', null, null, pub_ip, false)
+			.then(function (result) {
+				expect(mock_ec2.runInstancesAsync).to.have.been.calledWith(expected_run_args);
+
+				expect(health_check.wait_until_status).to.have.been.calledWith(region, instance_id, 'instanceExists');
+
+				expect(mock_ec2.createTagsAsync).to.have.been.calledWith({
+					Resources: [instance_id],
+					Tags: [tag_key]
+				});
+
+				expect(mock_ec2.describeAddressesAsync).to.have.been.calledWith({
+					PublicIps: [pub_ip]
+				});
+
+				expect(mock_ec2.disassociateAddressAsync).to.have.not.been.called;
+
+				expect(mock_ec2.associateAddressAsync).to.have.been.calledWith({
+					AllocationId: alloc_id,
+					InstanceId: instance_id
+				});
+
+				expect(result).eql([instance_id]);
+			});
+	});
+
+	it('does not attach an EIP when creating tags fails due to AWS error (or other fatal error) and throws an exception', function () {
+		let expected_err = new Error('Something wrong');
+		mock_ec2.createTagsAsync = sandbox.stub().returns(
+			Promise.reject(expected_err)
+		);
+		return instance
+			.create([region], null, 'image_id', null, null, null, 'iam', null, null, null, null, ['e'], [tag], 'fake-network-interface-id', null, null, pub_ip, true)
+			.then(function (result) {
+				expect(mock_ec2.runInstancesAsync).to.have.been.calledWith(expected_run_args);
+
+				expect(health_check.wait_until_status).to.have.been.calledWith(region, instance_id, 'instanceExists');
+
+				expect(mock_ec2.createTagsAsync).to.have.been.calledWith({
+					Resources: [instance_id],
+					Tags: [tag_key]
+				});
+
+				expect(mock_ec2.describeAddressesAsync).to.have.not.been.called;
+
+				expect(mock_ec2.disassociateAddressAsync).to.have.not.been.called;
+
+				expect(mock_ec2.associateAddressAsync).to.have.not.been.called;
+
+				expect(result).eql([instance_id]);
+			})
+			.catch(err => {
+				expect(err).to.eql(expected_err);
+			});
+	});
 });

--- a/tst/api/instance/create.test.js
+++ b/tst/api/instance/create.test.js
@@ -34,6 +34,7 @@ describe('instance create', function () {
 		));
 
 		sandbox.stub(health_check, 'wait_until_status').returns(Promise.resolve(instance_id));
+		sandbox.stub(health_check, 'wait_for_spinup_complete').returns(Promise.resolve(instance_id));
 
 		mock_ec2 = {
 			runInstancesAsync: sandbox.stub().returns(
@@ -132,6 +133,8 @@ describe('instance create', function () {
 
 				expect(health_check.wait_until_status).to.have.been.calledWith(region, instance_id, 'instanceExists');
 
+				expect(health_check.wait_for_spinup_complete).to.have.not.been.called;
+
 				expect(mock_ec2.describeAddressesAsync).to.have.not.been.called;
 
 				expect(mock_ec2.disassociateAddressAsync).to.have.not.been.called;
@@ -154,6 +157,8 @@ describe('instance create', function () {
 					Resources: [instance_id],
 					Tags: [tag_key]
 				});
+
+				expect(health_check.wait_for_spinup_complete).to.have.been.calledWith(region, instance_id);
 
 				expect(mock_ec2.describeAddressesAsync).to.have.been.calledWith({
 					PublicIps: [pub_ip]
@@ -184,6 +189,8 @@ describe('instance create', function () {
 					Resources: [instance_id],
 					Tags: [tag_key]
 				});
+
+				expect(health_check.wait_for_spinup_complete).to.have.not.been.called;
 
 				expect(mock_ec2.describeAddressesAsync).to.have.been.calledWith({
 					PublicIps: [pub_ip]
@@ -218,6 +225,8 @@ describe('instance create', function () {
 					Tags: [tag_key]
 				});
 
+				expect(health_check.wait_for_spinup_complete).to.have.not.been.called;
+
 				expect(mock_ec2.describeAddressesAsync).to.have.been.calledWith({
 					PublicIps: [pub_ip]
 				});
@@ -249,6 +258,8 @@ describe('instance create', function () {
 					Resources: [instance_id],
 					Tags: [tag_key]
 				});
+
+				expect(health_check.wait_for_spinup_complete).to.have.not.been.called;
 
 				expect(mock_ec2.describeAddressesAsync).to.have.not.been.called;
 

--- a/tst/api/instance/create.test.js
+++ b/tst/api/instance/create.test.js
@@ -126,7 +126,7 @@ describe('instance create', function () {
 
 	it('creates an instance with no elastic ip', function () {
 		return instance
-			.create([region], null, 'image_id', null, null, null, 'iam', null, null, null, null, ['e'], null, 'fake-network-interface-id', null, null, null, false)
+			.create([region], null, 'image_id', null, null, null, 'iam', null, null, null, null, ['e'], null, 'fake-network-interface-id', null, null, [], false)
 			.then(function (result) {
 				expect(mock_ec2.runInstancesAsync).to.have.been.calledWith(expected_run_args);
 
@@ -144,7 +144,7 @@ describe('instance create', function () {
 
 	it('creates an instance with an elastic ip when reassociate is true, and detaching and attaching succeeds', function () {
 		return instance
-			.create([region], null, 'image_id', null, null, null, 'iam', null, null, null, null, ['e'], [tag], 'fake-network-interface-id', null, null, pub_ip, true)
+			.create([region], null, 'image_id', null, null, null, 'iam', null, null, null, null, ['e'], [tag], 'fake-network-interface-id', null, null, [pub_ip], true)
 			.then(function (result) {
 				expect(mock_ec2.runInstancesAsync).to.have.been.calledWith(expected_run_args);
 
@@ -174,7 +174,7 @@ describe('instance create', function () {
 
 	it('creates an instance without an elastic IP when reassociate is false and an EIP is already attached', function () {
 		return instance
-			.create([region], null, 'image_id', null, null, null, 'iam', null, null, null, null, ['e'], [tag], 'fake-network-interface-id', null, null, pub_ip, false)
+			.create([region], null, 'image_id', null, null, null, 'iam', null, null, null, null, ['e'], [tag], 'fake-network-interface-id', null, null, [pub_ip], false)
 			.then(function (result) {
 				expect(mock_ec2.runInstancesAsync).to.have.been.calledWith(expected_run_args);
 
@@ -207,7 +207,7 @@ describe('instance create', function () {
 			})
 		);
 		return instance
-			.create([region], null, 'image_id', null, null, null, 'iam', null, null, null, null, ['e'], [tag], 'fake-network-interface-id', null, null, pub_ip, false)
+			.create([region], null, 'image_id', null, null, null, 'iam', null, null, null, null, ['e'], [tag], 'fake-network-interface-id', null, null, [pub_ip], false)
 			.then(function (result) {
 				expect(mock_ec2.runInstancesAsync).to.have.been.calledWith(expected_run_args);
 
@@ -239,7 +239,7 @@ describe('instance create', function () {
 			Promise.reject(expected_err)
 		);
 		return instance
-			.create([region], null, 'image_id', null, null, null, 'iam', null, null, null, null, ['e'], [tag], 'fake-network-interface-id', null, null, pub_ip, true)
+			.create([region], null, 'image_id', null, null, null, 'iam', null, null, null, null, ['e'], [tag], 'fake-network-interface-id', null, null, [pub_ip], true)
 			.then(function (result) {
 				expect(mock_ec2.runInstancesAsync).to.have.been.calledWith(expected_run_args);
 

--- a/tst/api/instance/replace.test.js
+++ b/tst/api/instance/replace.test.js
@@ -7,18 +7,23 @@ const sinon = require('sinon');
 const AWSProvider = require('../../../src/api/aws_provider');
 const AWSUtil = require('../../../src/api/aws_util');
 const instance = require('../../../src/api/instance');
+const health_check = require('../../../src/api/health_checks');
 
 
 describe('instance replace', function () {
 	let sandbox, mock_elb, mock_ec2;
-	let old_instance_id = '456';
-	let new_instance_id = '123';
-	let alloc_id = 'aloc123';
-	let assoc_id = 'assoc123';
-	let pub_ip = '999.999.999.999';
+	let old_instance_id, new_instance_id, alloc_id, assoc_id, pub_ip;
 
 	beforeEach(function () {
+		old_instance_id = '456';
+		new_instance_id = '123';
+		alloc_id = 'aloc123';
+		assoc_id = 'assoc123';
+		pub_ip = '999.999.999.999';
+
 		sandbox = sinon.sandbox.create();
+
+		sandbox.stub(health_check, 'wait_until_status').returns(Promise.resolve(new_instance_id));
 
 		mock_elb = {
 			registerInstancesWithLoadBalancerAsync: sandbox.stub().returns(

--- a/tst/api/instance/replace.test.js
+++ b/tst/api/instance/replace.test.js
@@ -7,23 +7,15 @@ const sinon = require('sinon');
 const AWSProvider = require('../../../src/api/aws_provider');
 const AWSUtil = require('../../../src/api/aws_util');
 const instance = require('../../../src/api/instance');
-const health_check = require('../../../src/api/health_checks');
 
 
 describe('instance replace', function () {
 	let sandbox, mock_elb, mock_ec2;
-	let old_instance_id, new_instance_id, alloc_id, assoc_id, pub_ip;
+	let old_instance_id = '456';
+	let new_instance_id = '123';
 
 	beforeEach(function () {
-		old_instance_id = '456';
-		new_instance_id = '123';
-		alloc_id = 'aloc123';
-		assoc_id = 'assoc123';
-		pub_ip = '999.999.999.999';
-
 		sandbox = sinon.sandbox.create();
-
-		sandbox.stub(health_check, 'wait_until_status').returns(Promise.resolve(new_instance_id));
 
 		mock_elb = {
 			registerInstancesWithLoadBalancerAsync: sandbox.stub().returns(
@@ -58,29 +50,6 @@ describe('instance replace', function () {
 		mock_ec2 = {
 			terminateInstancesAsync: sandbox.stub().returns(
 				Promise.resolve()
-			),
-			describeInstancesAsync: sandbox.stub().returns(
-				Promise.resolve({
-					Reservations: [{
-						Instances: [{
-							PublicIpAddress: pub_ip
-						}]
-					}]
-				})
-			),
-			describeAddressesAsync: sandbox.stub().returns(
-				Promise.resolve({
-					Addresses: [{
-						AllocationId: alloc_id,
-						AssociationId: assoc_id
-					}]
-				})
-			),
-			disassociateAddressAsync: sandbox.stub().returns(
-				Promise.resolve()
-			),
-			associateAddressAsync: sandbox.stub().returns(
-				Promise.resolve()
 			)
 		};
 
@@ -104,9 +73,9 @@ describe('instance replace', function () {
 		sandbox.restore();
 	});
 
-	it('replaces an instance when associating an elastic IP successfully', function () {
+	it('replaces an instance', function () {
 		return instance
-			.replace(['us-east-1'], 'old-instance', 'new-instance', true)
+			.replace(['us-east-1'], 'old-instance', 'new-instance')
 			.then(function () {
 				expect(mock_elb.registerInstancesWithLoadBalancerAsync).to.have.been.calledWith({
 					Instances: [{InstanceId: new_instance_id}],
@@ -129,269 +98,6 @@ describe('instance replace', function () {
 						]
 					}
 				);
-
-				expect(mock_ec2.describeInstancesAsync).to.have.been.calledWith({
-					Filters: [
-						{
-							Name: 'instance-id',
-							Values: [old_instance_id]
-						}
-					]
-				});
-
-				expect(mock_ec2.describeAddressesAsync).to.have.been.calledWith({
-					PublicIps: [pub_ip]
-				});
-
-				expect(mock_ec2.disassociateAddressAsync).to.have.been.calledWith({
-					AssociationId: assoc_id
-				});
-
-				expect(mock_ec2.associateAddressAsync).to.have.been.calledWith({
-					AllocationId: alloc_id,
-					InstanceId: new_instance_id
-				});
-			});
-	});
-
-	it('replaces an instance when not association an elastic IP successfully', function () {
-		return instance
-			.replace(['us-east-1'], 'old-instance', 'new-instance', false)
-			.then(function () {
-				expect(mock_elb.registerInstancesWithLoadBalancerAsync).to.have.been.calledWith({
-					Instances: [{InstanceId: new_instance_id}],
-					LoadBalancerName: 'lb'
-				});
-
-				expect(mock_elb.deregisterInstancesFromLoadBalancerAsync).to.have.been.calledWith({
-					Instances: [{InstanceId: old_instance_id}],
-					LoadBalancerName: 'lb'
-				});
-
-				expect(mock_elb.waitForAsync).to.have.been.calledWith(
-					'instanceInService',
-					{
-						LoadBalancerName: 'lb',
-						Instances: [
-							{
-								InstanceId: new_instance_id
-							}
-						]
-					}
-				);
-
-				expect(mock_ec2.describeInstancesAsync).to.not.have.been.called;
-
-				expect(mock_ec2.describeAddressesAsync).to.not.have.been.called;
-
-				expect(mock_ec2.disassociateAddressAsync).to.not.have.been.called;
-
-				expect(mock_ec2.associateAddressAsync).to.not.have.been.called;
-			});
-	});
-
-	it('replaces an instance when associate elastic IP but instance description not found', function () {
-		mock_ec2.describeInstancesAsync = sandbox.stub().returns(Promise.resolve({}));
-		return instance
-			.replace(['us-east-1'], 'old-instance', 'new-instance', true)
-			.then(function () {
-				expect(mock_elb.registerInstancesWithLoadBalancerAsync).to.have.been.calledWith({
-					Instances: [{InstanceId: new_instance_id}],
-					LoadBalancerName: 'lb'
-				});
-
-				expect(mock_elb.deregisterInstancesFromLoadBalancerAsync).to.have.been.calledWith({
-					Instances: [{InstanceId: old_instance_id}],
-					LoadBalancerName: 'lb'
-				});
-
-				expect(mock_elb.waitForAsync).to.have.been.calledWith(
-					'instanceInService',
-					{
-						LoadBalancerName: 'lb',
-						Instances: [
-							{
-								InstanceId: new_instance_id
-							}
-						]
-					}
-				);
-
-				expect(mock_ec2.describeInstancesAsync).to.have.been.calledWith({
-					Filters: [
-						{
-							Name: 'instance-id',
-							Values: [old_instance_id]
-						}
-					]
-				});
-
-				expect(mock_ec2.describeAddressesAsync).to.not.have.been.called;
-
-				expect(mock_ec2.disassociateAddressAsync).to.not.have.been.called;
-
-				expect(mock_ec2.associateAddressAsync).to.not.have.been.called;
-			});
-	});
-
-	it('replaces an instance when associate elastic IP but EIP not found', function () {
-		mock_ec2.describeAddressesAsync = sandbox.stub().returns(Promise.resolve({}));
-		return instance
-			.replace(['us-east-1'], 'old-instance', 'new-instance', true)
-			.then(function () {
-				expect(mock_elb.registerInstancesWithLoadBalancerAsync).to.have.been.calledWith({
-					Instances: [{InstanceId: new_instance_id}],
-					LoadBalancerName: 'lb'
-				});
-
-				expect(mock_elb.deregisterInstancesFromLoadBalancerAsync).to.have.been.calledWith({
-					Instances: [{InstanceId: old_instance_id}],
-					LoadBalancerName: 'lb'
-				});
-
-				expect(mock_elb.waitForAsync).to.have.been.calledWith(
-					'instanceInService',
-					{
-						LoadBalancerName: 'lb',
-						Instances: [
-							{
-								InstanceId: new_instance_id
-							}
-						]
-					}
-				);
-
-				expect(mock_ec2.describeInstancesAsync).to.have.been.calledWith({
-					Filters: [
-						{
-							Name: 'instance-id',
-							Values: [old_instance_id]
-						}
-					]
-				});
-
-				expect(mock_ec2.describeAddressesAsync).to.have.been.calledWith({
-					PublicIps: [pub_ip]
-				});
-
-				expect(mock_ec2.disassociateAddressAsync).to.not.have.been.called;
-
-				expect(mock_ec2.associateAddressAsync).to.not.have.been.called;
-			});
-	});
-
-	it('does not replace an instance when failure to detach EIP from target', function () {
-		let err_msg = new Error('dang');
-		mock_ec2.disassociateAddressAsync = sandbox.stub().returns(
-			Promise.reject(err_msg)
-		);
-		return instance
-			.replace(['us-east-1'], 'old-instance', 'new-instance', true)
-			.then(function () {
-				expect(mock_elb.registerInstancesWithLoadBalancerAsync).to.have.been.calledWith({
-					Instances: [{InstanceId: new_instance_id}],
-					LoadBalancerName: 'lb'
-				});
-
-				expect(mock_elb.deregisterInstancesFromLoadBalancerAsync).to.have.been.calledWith({
-					Instances: [{InstanceId: old_instance_id}],
-					LoadBalancerName: 'lb'
-				});
-
-				expect(mock_elb.waitForAsync).to.have.been.calledWith(
-					'instanceInService',
-					{
-						LoadBalancerName: 'lb',
-						Instances: [
-							{
-								InstanceId: new_instance_id
-							}
-						]
-					}
-				);
-
-				expect(mock_ec2.describeInstancesAsync).to.have.been.calledWith({
-					Filters: [
-						{
-							Name: 'instance-id',
-							Values: [old_instance_id]
-						}
-					]
-				});
-
-				expect(mock_ec2.describeAddressesAsync).to.have.been.calledWith({
-					PublicIps: [pub_ip]
-				});
-
-				expect(mock_ec2.disassociateAddressAsync).to.have.been.calledWith({
-					AssociationId: assoc_id
-				});
-
-				expect(mock_ec2.associateAddressAsync).to.not.have.been.called;
-
-				expect(mock_ec2.terminateInstancesAsync).to.not.have.been.called;
-			})
-			.catch(err => {
-				expect(err).to.eql(err_msg);
-			});
-	});
-
-	it('does not replace an instance when failure to attach EIP to source', function () {
-		let err_msg = new Error("Something wrong");
-		mock_ec2.associateAddressAsync = sandbox.stub().returns(
-			Promise.reject(err_msg)
-		);
-		return instance
-			.replace(['us-east-1'], 'old-instance', 'new-instance', true)
-			.then(function () {
-				expect(mock_elb.registerInstancesWithLoadBalancerAsync).to.have.been.calledWith({
-					Instances: [{InstanceId: new_instance_id}],
-					LoadBalancerName: 'lb'
-				});
-
-				expect(mock_elb.deregisterInstancesFromLoadBalancerAsync).to.have.been.calledWith({
-					Instances: [{InstanceId: old_instance_id}],
-					LoadBalancerName: 'lb'
-				});
-
-				expect(mock_elb.waitForAsync).to.have.been.calledWith(
-					'instanceInService',
-					{
-						LoadBalancerName: 'lb',
-						Instances: [
-							{
-								InstanceId: new_instance_id
-							}
-						]
-					}
-				);
-
-				expect(mock_ec2.describeInstancesAsync).to.have.been.calledWith({
-					Filters: [
-						{
-							Name: 'instance-id',
-							Values: [old_instance_id]
-						}
-					]
-				});
-
-				expect(mock_ec2.describeAddressesAsync).to.have.been.calledWith({
-					PublicIps: [pub_ip]
-				});
-
-				expect(mock_ec2.disassociateAddressAsync).to.have.been.calledWith({
-					AssociationId: assoc_id
-				});
-
-				expect(mock_ec2.associateAddressAsync).to.have.been.calledWith({
-					AllocationId: alloc_id,
-					InstanceId: new_instance_id
-				});
-
-				expect(mock_ec2.terminateInstancesAsync).to.not.have.been.called;
-			})
-			.catch(err => {
-				expect(err).to.eql(err_msg);
 			});
 	});
 });


### PR DESCRIPTION
- add 'elastic-ip' argument for instance create
- update tests
- generalize methods into AWSUtils
- Make disassociate/reassociate of EIPs happen last (after tagging)
- Update tests
- Make EIPs an array (matching to regions) for create instance